### PR TITLE
Fix typo in README for LspSagaRename command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ src="https://user-images.githubusercontent.com/41671631/105969051-c7fb7700-60c2-
 -- rename
 nnoremap <silent>gr <cmd>lua require('lspsaga.rename').rename()<CR>
 -- or command
-nnoremap <silent>gr :LspRename<CR>
+nnoremap <silent>gr :LspSagaRename<CR>
 ```
 <div align="center">
 <img


### PR DESCRIPTION
Nitpick...

Btw: I can't find it in the docs, but I think if you use the `<cmd>` prefix (which has many advantages next performance) you don't need to silence the commands. You use silence for with and without the `<cmd>`. Do you really need it? :thinking:  And is there a specific reason you mixed both variants? Just asking... :speak_no_evil: 