### PR TITLE
Fix server_filetype_map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lspsaga.nvim
 
-A light-weight lsp plugin based on neovim built-in lsp with highly performance UI.
+A light-weight lsp plugin based on neovim built-in lsp with highly a performant UI.
 
 ## Install
 
@@ -40,9 +40,9 @@ local saga = require 'lspsaga'
 -- 1: thin border | 2: rounded border | 3: thick border
 -- border_style = 1
 -- rename_prompt_prefix = '➤',
--- if you don't use nvim-lspconfig you must pass your filetype and server
--- command into this table
--- like server_filetype_map.scala = 'metals'
+-- if you don't use nvim-lspconfig you must pass your server name and
+-- the related filetypes into this table
+-- like server_filetype_map = {metals = {'sbt', 'scala'}}
 -- server_filetype_map = {}
 
 saga.init_lsp_saga {

--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -93,22 +93,22 @@ function libs.get_lsp_root_dir()
   if not active then print(msg) return end
   local clients = vim.lsp.get_active_clients()
   for _,client in pairs(clients) do
-    if client.config.root_dir then
-      if client.config.filetypes then
-        if type(client.config.filetypes) == "table" then
-          if libs.has_value(client.config.filetypes,vim.bo.filetype) then
-            return client.config.root_dir
-          end
-        elseif type(client.config.filetypes) == "string" then
-          if client.config.filetypes == vim.bo.filetype then
-            return client.config.root_dir
-          end
+    if (client.config.filetypes and client.config.root_dir) then
+      if type(client.config.filetypes) == "table" then
+        if libs.has_value(client.config.filetypes,vim.bo.filetype) then
+          return client.config.root_dir
+        end
+      elseif type(client.config.filetypes) == "string" then
+        if client.config.filetypes == vim.bo.filetype then
+          return client.config.root_dir
         end
       end
     else
-      for ft,cmd in pairs(server_filetype_map) do
-        if ft == vim.bo.filetype and client.config.cmd[1] == cmd then
-          return client.config.root_dir
+      for name,fts in pairs(server_filetype_map) do
+        for _, ft in pairs(fts) do
+          if (ft == vim.bo.filetype and client.config.name == name and client.config.root_dir) then
+            return client.config.root_dir
+          end
         end
       end
     end


### PR DESCRIPTION
This closes #57

This makes a few changes to the current `server_filetype_map`
functionality.

1. The logic used to be that you checked for `client.root_dir` first,
   and if that wasn't found, then you would look into the map. Instead,
   you should look to see if `config.filetypes` is defined first, if
   not, then you look into the map.
2. Instead of using `config.cmd` in the mapping, use `config.name`.
   Mainly because you can't always rely on `config.cmd` being a single
   executable. In the case of `nvim-metals` is a full path, in
   `nvim-jdtls` is a path to a script. So if you use name, the mapping
   becomes much simpler.
3. Swap around the value and key in the mapping so that a single server
   name can point to multiple filetypes. This is inline with how
   `config.filetypes` is, so probably best to keep the same. This is
   also important for Metals as we want to target both Scala and sbt
   files.

So now you would use this like so:

```lua
require('lspsaga').init_lsp_saga({
  server_filetype_map = {metals = {'sbt', 'scala'}}
})
```