### PR TITLE
Fix jump to diagnostics error

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -133,7 +133,7 @@ local function jump_to_entry(entry)
   local hiname ={"LspDiagErrorBorder","LspDiagWarnBorder","LspDiagInforBorder","LspDiagHintBorder"}
 
   -- add server source in diagnostic float window
-  local server_source = entry.source
+  local server_source = entry.source or ''
   local header = severity_icon[entry.severity] ..' '..'['.. server_source..']'
   if entry.message:find('\n') then
     entry.message = entry.message:gsub("[\n\r]", " ")


### PR DESCRIPTION
Just encountered an error when jumping to diagnostics

[![asciicast](https://asciinema.org/a/lZxa88F4hzmeCLLNm9FaQVMQE.svg)](https://asciinema.org/a/lZxa88F4hzmeCLLNm9FaQVMQE)

`E5108: Error executing lua ...ack/packer/start/lspsaga.nvim/lua/lspsaga/diagnostic.lua:137: attempt to concatenate local 'server_source' (a nil value)`