### PR TITLE
Windows lsp_finder fixes

### DIFF
--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -1,10 +1,17 @@
 local api = vim.api
-local is_windows = vim.loop.os_uname().sysname == "Windows"
-local path_sep = is_windows and '\\' or '/'
 local libs = {}
 local server_filetype_map = require('lspsaga').config_values.server_filetype_map
 
+function libs.is_windows()
+  return vim.loop.os_uname().sysname:find("Windows", 1, true) and true 
+end
+
+local path_sep = libs.is_windows() and '\\' or '/'
+
 function libs.get_home_dir()
+  if libs.is_windows() then
+    return os.getenv("USERPROFILE")
+  end
   return os.getenv("HOME")
 end
 

--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -3,7 +3,7 @@ local libs = {}
 local server_filetype_map = require('lspsaga').config_values.server_filetype_map
 
 function libs.is_windows()
-  return vim.loop.os_uname().sysname:find("Windows", 1, true) and true 
+  return vim.loop.os_uname().sysname:find("Windows", 1, true) and true
 end
 
 local path_sep = libs.is_windows() and '\\' or '/'

--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -82,7 +82,7 @@ function libs.result_isempty(res)
 end
 
 function libs.split_by_pathsep(text,start_pos)
-  local pattern = is_windows and path_sep or '/'..path_sep
+  local pattern = libs.is_windows() and path_sep or '/'..path_sep
   local short_text = ''
   local split_table = {}
   for word in text:gmatch('[^'..pattern..']+') do

--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -111,7 +111,10 @@ function Finder:create_finder_contents(result,method_type,root_dir)
       if not api.nvim_buf_is_loaded(bufnr) then
         vim.fn.bufload(bufnr)
       end
-      local link = vim.uri_to_fname(uri)
+      local link = vim.uri_to_fname(uri) -- returns lowercase drive letters on Windows
+      if libs.is_windows() then
+        link = link:gsub('^%l', link:sub(1, 1):upper())
+      end
       local short_name
 
       -- reduce filename length by root_dir or home dir


### PR DESCRIPTION
vim.loop.os_uname().sysname appears to return "Windows_NT", so the
in_windows check was changed to check for a substring instead of
straight equality. This was also migrated to a function to perform a
similar check in provi.ers.lua.

os.getenv("HOME") returns nil on Windows. os.getenv("USERPROFILE") is
appropriate on Windows.

vim.uri_to_fname() returns paths with lowercase drive letters on Windows
for some reason. Before the paths are shortened for the lsp_finder
results, a check for Windows was added, along with a substitution of the
drive letter for the appropriate uppercase version.

I'm no lua wizard, but I took a swing at it. I'm not sure if I caught all the Windows edge cases. I basically just worked through the hangups until I got lsp_finder working. Let me know if there is something else which should be looked into. 