### PR TITLE
feat: add `border_style=4` (ascii border)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ local saga = require 'lspsaga'
 --   open = 'o', vsplit = 's',split = 'i',quit = 'q',scroll_down = '<C-f>', scroll_up = '<C-b>'
 -- },
 -- definition_preview_icon = '  '
--- 1: thin border | 2: rounded border | 3: thick border
+-- 1: thin border | 2: rounded border | 3: thick border | 4: ascii border
 -- border_style = 1
 -- rename_prompt_prefix = '➤',
 -- if you don't use nvim-lspconfig you must pass your server name and

--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -5,10 +5,12 @@ local wrap = require('lspsaga.wrap')
 -- 1 thin
 -- 2 radio
 -- 3 crude
+-- 4 ascii
 local border_style = {
   {top_left = "┌",top_mid = "─",top_right = "┐",mid = "│",bottom_left = "└",bottom_right= "┘" };
   {top_left = "╭",top_mid = "─",top_right = "╮",mid = "│",bottom_left = "╰",bottom_right= "╯" };
   {top_left = "┏",top_mid = "━",top_right = "┓",mid = "┃",bottom_left = "┗",bottom_right = "┛"};
+  {top_left = "+",top_mid = "-",top_right = "+",mid = "|",bottom_left = "+",bottom_right = "+"};
 }
 
 function M.get_max_contents_width(contents)

--- a/lua/lspsaga/wrap.lua
+++ b/lua/lspsaga/wrap.lua
@@ -1,3 +1,4 @@
+local config = require('lspsaga').config_values
 local wrap = {}
 
 -- If the content too long.
@@ -61,7 +62,8 @@ end
 function wrap.add_truncate_line(contents)
   local line_widths = {}
   local width = 0
-  local truncate_line = '─'
+  local char = config.border_style == 4 and '-' or '─'
+  local truncate_line = char
 
   for i,line in ipairs(contents) do
     line_widths[i] = vim.fn.strdisplaywidth(line)
@@ -69,7 +71,7 @@ function wrap.add_truncate_line(contents)
   end
 
   for _=1,width,1 do
-    truncate_line = truncate_line .. '─'
+    truncate_line = truncate_line .. char
   end
 
   return truncate_line


### PR DESCRIPTION
Thank you for creating a very cool plugin!

I am using `set ambwidth=double` and am having problems with the display broken.

Therefore, ascii characters can now be used in `border_style`.
Also, when `border_style=4`, ascii characters will be used in `wrap.lua`.

**Screenshot**


before: `border_style=1`

<img width="790" alt="before" src="https://user-images.githubusercontent.com/16581287/107439520-8adcbd80-6b75-11eb-9fc0-a70c7ba20ac9.png">

after: `border_style=4`

<img width="457" alt="after" src="https://user-images.githubusercontent.com/16581287/107439584-a47e0500-6b75-11eb-951e-c9084b40f8b1.png">
