### PR TITLE
Fix nil error when attempting code action.

### DIFF
--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -82,8 +82,6 @@ end
 function Action:code_action(context)
   local active,msg = libs.check_lsp_active()
   if not active then print(msg) return end
-  -- if exist diagnostic float window close it
-  require('lspsaga.diagnostic').close_preview()
 
   self.bufnr = vim.fn.bufnr()
   vim.validate { context = { context, 't', true } }


### PR DESCRIPTION
In
https://github.com/glepnir/lspsaga.nvim/commit/8847e8b91579dd62e325f99f202092953b6793ed
`close_preview()` was removed from diagnostic. So this line is causing:

```
E5108: Error executing lua ...ack/packer/start/lspsaga.nvim/lua/lspsaga/codeaction.lua:86: attempt to call field 'close_preview' (a nil value
)
```

when someone tries to do a code action now.