### PR TITLE
fix signaturehelp

### DIFF
--- a/lua/lspsaga/signaturehelp.lua
+++ b/lua/lspsaga/signaturehelp.lua
@@ -20,12 +20,8 @@ local function check_server_support_signaturehelp()
   local active,msg = libs.check_lsp_active()
   if not active then print(msg) return end
   local clients = vim.lsp.get_active_clients()
-  for _,client in ipairs(clients) do
-    if client.name == "efm" then
-      return false
-    end
-  end
-  return true
+  local isOnlyEfm = vim.tbl_count(clients) == 1 and clients[1].name == "efm"
+  return not isOnlyEfm
 end
 
 local function focusable_float(unique_name, fn)


### PR DESCRIPTION
that pr fixes check for signature_help when `efm` is used ( previously if there `efm` first lsp it returned `false` which is not always correct )