### PR TITLE
fix: review_definition with multiple servers

### DIFF
--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -445,7 +445,7 @@ function lspfinder.preview_definition(timeout_ms)
       print("No location found: " .. method)
       return nil
   end
-  result = {vim.tbl_deep_extend("force", unpack(result))}
+  result = {vim.tbl_deep_extend("force", {}, unpack(result))}
   if vim.tbl_islist(result) and not vim.tbl_isempty(result[1]) then
     local uri = result[1].result[1].uri or result[1].result[1].targetUri
     if #uri == 0 then return end

--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -445,6 +445,7 @@ function lspfinder.preview_definition(timeout_ms)
       print("No location found: " .. method)
       return nil
   end
+  result = {vim.tbl_deep_extend("force", unpack(result))}
   if vim.tbl_islist(result) and not vim.tbl_isempty(result[1]) then
     local uri = result[1].result[1].uri or result[1].result[1].targetUri
     if #uri == 0 then return end


### PR DESCRIPTION
the current implementation fails when there is multiple results

current result array
```lua
{
  {
    result = {}
  },
  {
    result = {
      {
        range = {
          end = {
            character = 20,
            line = 42
          },
          start = {
            character = 12,
            line = 42
          }
        },
        uri = "file:///<path>/app/node_modules/next/types/index.d.ts"
      }
    }
  }
}
```

after PR
```pr
{
  {
    result = {
      {
        range = {
          end = {
            character = 20,
            line = 42
          },
          start = {
            character = 12,
            line = 42
          }
        },
        uri = "file:///home/ashraf/projects/veve/app/node_modules/next/types/index.d.ts"
      }
    }
  }
}
```