### PR TITLE
Fix diagnostics conflicting with hover doc

### DIFF
--- a/lua/lspsaga/command.lua
+++ b/lua/lspsaga/command.lua
@@ -12,6 +12,7 @@ local subcommands = {
   preview_definition = provider.preview_definition,
   rename = lsprename.rename,
   hover_doc = lsphover.render_hover_doc,
+  show_cursor_diagnostics = diagnostic.show_cursor_diagnostics,
   show_line_diagnostics = diagnostic.show_line_diagnostics,
   diagnostic_jump_next = diagnostic.lsp_jump_diagnostic_next,
   diagnostic_jump_prev = diagnostic.lsp_jump_diagnostic_prev,

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -45,6 +45,14 @@ function M.lsp_jump_diagnostic_prev(opts)
 end
 
 local function show_diagnostics(opts, get_diagnostics)
+  local close_hover = opts.close_hover or false
+
+  -- if we have a hover rendered, don't show diagnostics due to this usually
+  -- being bound to CursorHold which triggers after hover show
+  if not close_hover and hover.has_saga_hover() then
+    return
+  end
+
   local active,_ = libs.check_lsp_active()
   if not active then return end
   local max_width = window.get_max_float_width()


### PR DESCRIPTION
If I try render the hover window with `render_hover_doc`, `show_cursor_diagnostics` immediately dismisses the hover doc and render the diagnostics again (happens with `show_line_diagnostics` too). I _think_ this is due to `CursorHold` triggering after `render_hover_doc` which I have bound to show cursor diagnostics
```lua
vim.api.nvim_command('autocmd CursorHold <buffer> lua require("lspsaga.diagnostic").show_cursor_diagnostics()')
```

I've added a check to see if hover doc is present before rendering the diagnostic and provided a way to override it if the function is bound to something else.