### PR TITLE
Apply severity sorting to all diagnostics before rendering

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -177,7 +177,7 @@ end
 function M.show_cursor_diagnostics(opts, bufnr, client_id)
   opts = opts or {}
 
-  local get_line_diagnostics = function()
+  local get_cursor_diagnostics = function()
     bufnr = bufnr or 0
 
     line_nr = vim.api.nvim_win_get_cursor(0)[1] - 1
@@ -188,7 +188,7 @@ function M.show_cursor_diagnostics(opts, bufnr, client_id)
     )
   end
 
-  return show_diagnostics(opts, get_line_diagnostics)
+  return show_diagnostics(opts, get_cursor_diagnostics)
 end
 
 function M.show_line_diagnostics(opts, bufnr, line_nr, client_id)

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -44,6 +44,10 @@ function M.lsp_jump_diagnostic_prev(opts)
   )
 end
 
+local function comp_severity_asc(diag1, diag2)
+  return diag1["severity"] < diag2["severity"]
+end
+
 local function show_diagnostics(opts, get_diagnostics)
   local close_hover = opts.close_hover or false
 
@@ -66,8 +70,7 @@ local function show_diagnostics(opts, get_diagnostics)
     end
   end
 
-  opts.severity_sort = if_nil(opts.severity_sort, true)
-
+  local severity_sort = if_nil(opts.severity_sort, true)
   local show_header = if_nil(opts.show_header, true)
 
   local lines = {}
@@ -80,7 +83,11 @@ local function show_diagnostics(opts, get_diagnostics)
   local diagnostics = get_diagnostics()
   if vim.tbl_isempty(diagnostics) then return end
 
-  for i, diagnostic in ipairs(diagnostics) do
+  local sorted_diagnostics = severity_sort
+    and table.sort(diagnostics, comp_severity_asc)
+    or diagnostics
+
+  for i, diagnostic in ipairs(sorted_diagnostics) do
     local prefix = string.format("%d. ", i)
     local hiname = lsp.diagnostic._get_floating_severity_highlight_name(diagnostic.severity)
     assert(hiname, 'unknown severity: ' .. tostring(diagnostic.severity))


### PR DESCRIPTION
I don't _think_ the [`opts.severity_sort`](https://github.com/glepnir/lspsaga.nvim/blob/main/lua/lspsaga/diagnostic.lua#L69) was doing anything so I've made it do what I think it should - happy to change it though