### PR TITLE
Add show_cursor_diagnostics to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ nnoremap <silent><leader>cd <cmd>lua
 require'lspsaga.diagnostic'.show_line_diagnostics()<CR>
 
 nnoremap <silent> <leader>cd :Lspsaga show_line_diagnostics<CR>
+-- only show diagnostic if cursor is over the area
+nnoremap <silent><leader>cc <cmd>lua
+require'lspsaga.diagnostic'.show_cursor_diagnostics()<CR>
+
 -- jump diagnostic
 nnoremap <silent> [e <cmd>lua require'lspsaga.diagnostic'.lsp_jump_diagnostic_prev()<CR>
 nnoremap <silent> ]e <cmd>lua require'lspsaga.diagnostic'.lsp_jump_diagnostic_next()<CR>


### PR DESCRIPTION
@glepnir I noticed that this function was added in a recent PR but is not in the README. It's actually quite helpful depending on your preference especially if used for an autocommand, so I've added it