### PR TITLE
feat(window): avoid pmenu

### DIFF
--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -73,13 +73,13 @@ local function make_floating_popup_options(width, height, opts)
     local lines_below = vim.fn.winheight(0) - lines_above
     new_option.anchor = ''
 
-    if lines_above < lines_below then
-      new_option.anchor = new_option.anchor..'N'
-      height = math.min(lines_below, height)
+    local pum_pos = vim.fn.pum_getpos()
+    local pum_vis = not vim.tbl_isempty(pum_pos) -- pumvisible() can be true and pum_pos() returns {}
+    if pum_vis and vim.fn.line(".") >= pum_pos.row or not pum_vis and lines_above < lines_below then
+      new_option.anchor = 'N'
       new_option.row = 1
     else
-      new_option.anchor = new_option.anchor..'S'
-      height = math.min(lines_above, height)
+      new_option.anchor = 'S'
       new_option.row = -2
     end
 


### PR DESCRIPTION
I'm using a simple helper function to show the signature help for a function while I am typing within it. The problem is that the completion menu will be placed over the floating signature help. A simple fix for this is to just detect if the popup menu is visible and set the anchor accordingly.


![image](https://user-images.githubusercontent.com/24252670/115150177-29e2d180-a05f-11eb-929e-278f5e3fd09e.png)

![image](https://user-images.githubusercontent.com/24252670/115150211-5c8cca00-a05f-11eb-9b2d-25b5d2b4ee77.png)
