### PR TITLE
fix(window): fix renamed _trim method

### DIFF
--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -146,7 +146,7 @@ function M.create_win_with_border(content_opts,opts)
   local bufnr = api.nvim_create_buf(false, true)
   -- buffer settings for contents buffer
   -- Clean up input: trim empty lines from the end, pad
-  local content = vim.lsp.util._trim(contents)
+  local content = vim.lsp.util._trim_and_pad(contents)
 
   if filetype then
     api.nvim_buf_set_option(bufnr, 'filetype', filetype)


### PR DESCRIPTION
It seems that the `vim.lsp.util._trim` was renamed to `vim.lsp.util._trim_and_pad`, this was causing this error when trying to open the floaterm:
`E5108: Error executing lua ...te/pack/packer/start/lspsaga.nvim/lua/lspsaga/window.lua:149: attempt to call field '_trim' (a nil value)`