### PR TITLE
feat: add hi LspFloatWinNormal (close #183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The available highlight groups are:
 | Group Name               | Description                                                      |
 | :----------------------- | :----------------------------------------------------------------|
 | `LspSagaFinderSelection` | Currently active entry in the finder window that gets previewed. |
+| `LspFloatWinNormal` | |
 | `LspFloatWinBorder` | |
 | `LspSagaBorderTitle` | |
 | `TargetWord` | |

--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -162,7 +162,7 @@ function M.create_win_with_border(content_opts,opts)
     api.nvim_win_set_option(winid, 'conceallevel', 2)
   end
 
-  api.nvim_win_set_option(winid,"winhl","Normal:NormalFloat,FloatBorder:"..highlight)
+  api.nvim_win_set_option(winid,"winhl","Normal:LspFloatWinNormal,FloatBorder:"..highlight)
   api.nvim_win_set_option(winid,'winblend',0)
   api.nvim_win_set_option(winid, 'foldlevel', 100)
   return bufnr,winid

--- a/plugin/lspsaga.vim
+++ b/plugin/lspsaga.vim
@@ -19,7 +19,7 @@ highlight default LspSagaFinderSelection guifg=#89d957 guibg=NONE gui=bold
 highlight default LspFloatWinBorder guifg=black guibg=NONE
 highlight default LspSagaBorderTitle guifg=orange guibg=NONE gui=bold
 
-hi link  NormalFloat Normal
+highlight default link LspFloatWinNormal Normal
 highlight default link TargetWord Error
 highlight default link ReferencesCount Title
 highlight default link DefinitionCount Title


### PR DESCRIPTION
Added a highlight to be used for the floating window `Normal` used in lspsaga.

I named it `LspFloatWinNormal` to match the highlight name of `LspFloatWinBorder`.
If you don't like it, please let me know. I will fix it.

Refer #180, #183