### PR TITLE
Fix preview_definition when definition comes from server ID 2

### DIFF
--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -443,7 +443,7 @@ function lspfinder.preview_definition(timeout_ms)
     print("No location found: " .. method)
     return nil
   end
-  result = {vim.tbl_deep_extend("force", {}, unpack(result))}
+  result = vim.tbl_values(result)
 
   if vim.tbl_islist(result) and not vim.tbl_isempty(result[1]) then
     local uri = result[1].result[1].uri or result[1].result[1].targetUri


### PR DESCRIPTION
Related to #128 

I found in my TypeScript code that `definition_preview` is intermittently broken producing the below error.
```
E5108: Error executing lua vim/shared.lua:219: after the second argument: expected table, got nil                                                                                                                                               
stack traceback:                                                                                                                                                                                                                                
        vim/shared.lua:219: in function 'tbl_deep_extend'                                                                                                                                                                                       
        .../pack/packer/start/lspsaga.nvim/lua/lspsaga/provider.lua:446: in function <.../pack/packer/start/lspsaga.nvim/lua/lspsaga/provider.lua:434>                                                                                          
        ...e/pack/packer/start/lspsaga.nvim/lua/lspsaga/command.lua:37: in function 'load_command'                                                                                                                                              
        [string ":lua"]:1: in main chunk
```

It seems down to what ID the LSP server is assigned which seems non-deterministic. If my `diagnosticls` gets ID 1 and `typescript` is ID 2 then it'll error - you can see the IDs in `:LspInfo`.

I think this ultimately comes down the line the error is generated on 
https://github.com/glepnir/lspsaga.nvim/blob/cb0e35d2e594ff7a9c408d2e382945d56336c040/lua/lspsaga/provider.lua#L446

Running `unpack` on an table like the below results in `nil` which triggers the error.
```lua
{                                                                                                                                                                                                                                               
  [2] = {                                                                                                                                                                                                                                       
    result = { {                                                                                                                                                                                                                                
        range = {                                                                                                                                                                                                                               
          end = {                                                                                                                                                                                                                               
            character = 19,                                                                                                                                                                                                                     
            line = 29                                                                                                                                                                                                                           
          },                                                                                                                                                                                                                                    
          start = {                                                                                                                                                                                                                             
            character = 13,                                                                                                                                                                                                                     
            line = 29                                                                                                                                                                                                                           
          }                                                                                                                                                                                                                                     
        },                                                                                                                                                                                                                                      
        uri = "file:///Users/thomas.payne/git/Client/node_modules/%40types/react-dom/index.d.ts"                                                                                                
      } }                                                                                                                                                                                                                                       
  }                                                                                                                                                                                                                                             
}
```

By swapping to `vim.tbl_values` it does seem to fix the error though the behaviour is slightly changed. It'll now always use the definition from the lowest ID server whereas before I _think_ it would use the highest (due to `vim.tbl_deep_extend("force", ...)`)