### PR TITLE
refactor: correct typo ("wraped" -> "wrapped")

### DIFF
--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -291,7 +291,7 @@ function M.fancy_floating_markdown(contents, opts)
 
   stripped = wrap.wrap_contents(stripped,width)
 
-  local wraped_index = #wrap.wrap_text(firstline,width)
+  local wrapped_index = #wrap.wrap_text(firstline,width)
 
   -- if only has one line do not insert truncate line
   if #stripped ~= 1 then
@@ -299,13 +299,13 @@ function M.fancy_floating_markdown(contents, opts)
     if stripped[1]:find('{%s$') then
       for idx,text in ipairs(stripped) do
         if text == '} ' or text == '}' then
-          wraped_index = idx
+          wrapped_index = idx
           break
         end
       end
     end
-    if wraped_index ~= #stripped then
-      table.insert(stripped,wraped_index+1,truncate_line)
+    if wrapped_index ~= #stripped then
+      table.insert(stripped,wrapped_index+1,truncate_line)
     end
   end
 
@@ -320,7 +320,7 @@ function M.fancy_floating_markdown(contents, opts)
   local height = opts.height or #stripped
   api.nvim_win_set_var(0,'lspsaga_hoverwin_data',{winid,height,height,#stripped})
 
-  api.nvim_buf_add_highlight(bufnr,-1,'LspSagaDocTruncateLine',wraped_index,0,-1)
+  api.nvim_buf_add_highlight(bufnr,-1,'LspSagaDocTruncateLine',wrapped_index,0,-1)
 
   -- Switch to the floating window to apply the syntax highlighting.
   -- This is because the syntax command doesn't accept a target.
@@ -346,7 +346,7 @@ function M.fancy_floating_markdown(contents, opts)
   -- make sure that regions between code blocks are definitely markdown.
   -- local ph = {start = 0; finish = 1;}
   for _, h in ipairs(highlights) do
-    h.finish = wraped_index
+    h.finish = wrapped_index
     -- apply_syntax_to_region('markdown', ph.finish, h.start)
     apply_syntax_to_region(h.ft, h.start, h.finish)
     -- ph = h


### PR DESCRIPTION
Just a simple find-and-replace.