### PR TITLE
Fix a mismatch of lightbulb highlight group name

### DIFF
--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -19,7 +19,7 @@ local SIGN_GROUP = "sagalightbulb"
 local SIGN_NAME = "LspSagaLightBulb"
 
 if vim.tbl_isempty(vim.fn.sign_getdefined(SIGN_NAME)) then
-  vim.fn.sign_define(SIGN_NAME, { text = config.code_action_icon, texthl = "LspSagaLightBulbSign" })
+  vim.fn.sign_define(SIGN_NAME, { text = config.code_action_icon, texthl = "LspSagaLightBulb" })
 end
 
 local function _update_virtual_text(line)


### PR DESCRIPTION
Change the texthl argument for the lightbulb sign from `LspSagaLightBulbSign` to `LspSagaLightBub` so that it match the default highlight group definition in `plugin/lspsaga.vim`.