### PR TITLE
Fix show_header false line in diagnostic, add prefix config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,202 +1,89 @@
 # lspsaga.nvim
 
-A light-weight lsp plugin based on neovim built-in lsp with highly a performant UI.
+A maintained fork of glepnir/lspsaga.nvim.
+
+Lspsaga is light-weight lsp plugin based on neovim built-in lsp with highly a performant UI. [SEE IN ACTION](https://github.com/tami5/lspsaga.nvim/wiki)
+
+## Features
+
+TODO .......
 
 ## Install
 
-* vim-plug
-```vim
-Plug 'neovim/nvim-lspconfig'
-Plug 'glepnir/lspsaga.nvim'
-```
-
-## Usage
-
-Lspsaga support use command `Lspsaga` with completion or use lua function
+### Packer
 
 ```lua
+use { 'tami5/lspsaga.nvim' } 
+```
 
-local saga = require 'lspsaga'
+## Requirements
 
--- add your config value here
--- default value
--- use_saga_diagnostic_sign = true
--- error_sign = '',
--- warn_sign = '',
--- hint_sign = '',
--- infor_sign = '',
--- dianostic_header_icon = '   ',
--- code_action_icon = ' ',
--- code_action_prompt = {
---   enable = true,
---   sign = true,
---   sign_priority = 20,
---   virtual_text = true,
--- },
--- finder_definition_icon = '  ',
--- finder_reference_icon = '  ',
--- max_preview_lines = 10, -- preview lines of lsp_finder and definition preview
--- finder_action_keys = {
---   open = 'o', vsplit = 's',split = 'i',quit = 'q',scroll_down = '<C-f>', scroll_up = '<C-b>' -- quit can be a table
--- },
--- code_action_keys = {
---   quit = 'q',exec = '<CR>'
--- },
--- rename_action_keys = {
---   quit = '<C-c>',exec = '<CR>'  -- quit can be a table
--- },
--- definition_preview_icon = '  '
--- "single" "double" "round" "plus"
--- border_style = "single"
--- rename_prompt_prefix = '➤',
--- if you don't use nvim-lspconfig you must pass your server name and
--- the related filetypes into this table
--- like server_filetype_map = {metals = {'sbt', 'scala'}}
--- server_filetype_map = {}
+- neovim/nvim-lspconfig
+- NEOVIM NIGHTLY (`+v0.6.0-dev+1865-g3beea1fe1`) or use nvim51 branch `use { 'tami5/lspsaga.nvim', branch = 'nvim51' } `
 
-saga.init_lsp_saga {
-  your custom option here
+## Setup
+
+Lspsaga support use command `Lspsaga` with completion or use lua function.
+
+```lua
+local lspsaga = require 'lspsaga'
+lspsaga.setup { -- defaults ...
+  debug = false,
+  use_saga_diagnostic_sign = true,
+  -- diagnostic sign
+  error_sign = "",
+  warn_sign = "",
+  hint_sign = "",
+  infor_sign = "",
+  dianostic_header_icon = "   ",
+  -- code action title icon
+  code_action_icon = " ",
+  code_action_prompt = {
+    enable = true,
+    sign = true,
+    sign_priority = 40,
+    virtual_text = true,
+  },
+  finder_definition_icon = "  ",
+  finder_reference_icon = "  ",
+  max_preview_lines = 10,
+  finder_action_keys = {
+    open = "o",
+    vsplit = "s",
+    split = "i",
+    quit = "q",
+    scroll_down = "<C-f>",
+    scroll_up = "<C-b>",
+  },
+  code_action_keys = {
+    quit = "q",
+    exec = "<CR>",
+  },
+  rename_action_keys = {
+    quit = "<C-c>",
+    exec = "<CR>",
+  },
+  definition_preview_icon = "  ",
+  border_style = "single",
+  rename_prompt_prefix = "➤",
+  server_filetype_map = {},
 }
-
-or --use default config
-saga.init_lsp_saga()
 ```
-
-### Async Lsp Finder
+## Example Keymapings
 
 ```lua
--- lsp provider to find the cursor word definition and reference
-nnoremap <silent> gh <cmd>lua require'lspsaga.provider'.lsp_finder()<CR>
--- or use command LspSagaFinder
-nnoremap <silent> gh :Lspsaga lsp_finder<CR>
+--- In lsp attach function
+local map = nvim_buf_set_keymap,
+map(0, "n", "gr", "<cmd>Lspsaga rename<cr>", {silent = true, noremap = true})
+map(0, "n", "gx", "<cmd>Lspsaga code_action<cr>", {silent = true, noremap = true})
+map(0, "x", "gx", ":<c-u>Lspsaga range_code_action<cr>", {silent = true, noremap = true})
+map(0, "n", "K",  "<cmd>Lspsaga hover_doc<cr>", {silent = true, noremap = true})
+map(0, "n", "go", "<cmd>Lspsaga show_line_diagnostics<cr>", {silent = true, noremap = true})
+map(0, "n", "gj", "<cmd>Lspsaga diagnostic_jump_next<cr>", {silent = true, noremap = true})
+map(0, "n", "gk", "<cmd>Lspsaga diagnostic_jump_prev<cr>", {silent = true, noremap = true})
+map(0, "n", "<C-u>", "<cmd>lua require('lspsaga.action').smart_scroll_with_saga(-1)<cr>")
+map(0, "n", "<C-d>", "<cmd>lua require('lspsaga.action').smart_scroll_with_saga(1)<cr>")
 ```
-<div align='center'>
-<img
-src="https://user-images.githubusercontent.com/41671631/107140076-ae77ec00-695a-11eb-8329-0b9d8361bfeb.gif" width=500 height=500/>
-</div>
-
-### Code Action
-
-```lua
--- code action
-nnoremap <silent><leader>ca <cmd>lua require('lspsaga.codeaction').code_action()<CR>
-vnoremap <silent><leader>ca :<C-U>lua require('lspsaga.codeaction').range_code_action()<CR>
--- or use command
-nnoremap <silent><leader>ca :Lspsaga code_action<CR>
-vnoremap <silent><leader>ca :<C-U>Lspsaga range_code_action<CR>
-```
-<div align='center'>
-<img
-src="https://user-images.githubusercontent.com/41671631/105657414-490a1100-5eff-11eb-897d-587ac1375d4e.gif" width=500 height=500/>
-</div>
-
-- code action auto prompt
-
-<div align='center'>
-<img
-src="https://user-images.githubusercontent.com/41671631/110590664-0e102400-81b3-11eb-9b9d-a894537104bc.gif" width=500 height=500/>
-</div>
-
-### Hover Doc
-
-```lua
--- show hover doc
-nnoremap <silent> K <cmd>lua require('lspsaga.hover').render_hover_doc()<CR>
--- or use command
-nnoremap <silent>K :Lspsaga hover_doc<CR>
-
--- scroll down hover doc or scroll in definition preview
-nnoremap <silent> <C-f> <cmd>lua require('lspsaga.action').smart_scroll_with_saga(1)<CR>
--- scroll up hover doc
-nnoremap <silent> <C-b> <cmd>lua require('lspsaga.action').smart_scroll_with_saga(-1)<CR>
-```
-<div align='center'>
-<img
-src="https://user-images.githubusercontent.com/41671631/106566308-1dc09b00-656b-11eb-85e2-2ab5b23599c9.gif" width=500 height=500/>
-</div>
-
-### SignatureHelp
-
-```lua
--- show signature help
-nnoremap <silent> gs <cmd>lua require('lspsaga.signaturehelp').signature_help()<CR>
--- or command
-nnoremap <silent> gs :Lspsaga signature_help<CR>
-
-and you also can use smart_scroll_with_saga to scroll in signature help win
-```
-<div align='center'>
-<img
-src="https://user-images.githubusercontent.com/41671631/105969051-c7fb7700-60c2-11eb-9c79-aef3e01d88b1.gif" width=500 height=500 />
-</div>
-
-### Rename
-
-```lua
--- rename
-nnoremap <silent>gr <cmd>lua require('lspsaga.rename').rename()<CR>
--- or command
-nnoremap <silent>gr :Lspsaga rename<CR>
--- close rename win use <C-c> in insert mode or `q` in noremal mode or `:q`
-```
-<div align="center">
-<img
-src="https://user-images.githubusercontent.com/41671631/106115648-f6915480-618b-11eb-9818-003cfb15c8ac.gif" />
-</div>
-
-### Preview Definition
-
-```lua
--- preview definition
-nnoremap <silent> gd <cmd>lua require'lspsaga.provider'.preview_definition()<CR>
--- or use command
-nnoremap <silent> gd :Lspsaga preview_definition<CR>
-
-can use smart_scroll_with_saga to scroll
-```
-<div align='center'>
-<img
-src="https://user-images.githubusercontent.com/41671631/105657900-5b387f00-5f00-11eb-8b39-4d3b1433cb75.gif" width=500 height=500/>
-</div>
-
-### Jump Diagnostic and Show Diagnostics
-
-```lua
--- show
-nnoremap <silent><leader>cd <cmd>lua
-require'lspsaga.diagnostic'.show_line_diagnostics()<CR>
-
-nnoremap <silent> <leader>cd :Lspsaga show_line_diagnostics<CR>
--- only show diagnostic if cursor is over the area
-nnoremap <silent><leader>cc <cmd>lua
-require'lspsaga.diagnostic'.show_cursor_diagnostics()<CR>
-
--- jump diagnostic
-nnoremap <silent> [e <cmd>lua require'lspsaga.diagnostic'.lsp_jump_diagnostic_prev()<CR>
-nnoremap <silent> ]e <cmd>lua require'lspsaga.diagnostic'.lsp_jump_diagnostic_next()<CR>
--- or use command
-nnoremap <silent> [e :Lspsaga diagnostic_jump_next<CR>
-nnoremap <silent> ]e :Lspsaga diagnostic_jump_prev<CR>
-```
-<div align='center'>
-<img
-src="https://user-images.githubusercontent.com/41671631/102290042-21786e00-3f7b-11eb-8026-d467bc256ba8.gif" width=500 height=300/>
-</div>
-
-### Float Terminal
-
-```lua
--- float terminal also you can pass the cli command in open_float_terminal function
-nnoremap <silent> <A-d> <cmd>lua require('lspsaga.floaterm').open_float_terminal()<CR> -- or open_float_terminal('lazygit')<CR>
-tnoremap <silent> <A-d> <C-\><C-n>:lua require('lspsaga.floaterm').close_float_terminal()<CR>
--- or use command
-nnoremap <silent> <A-d> :Lspsaga open_floaterm<CR>
-tnoremap <silent> <A-d> <C-\><C-n>:Lspsaga close_floaterm<CR>
-```
-<div align='center'>
-<img
-src="https://user-images.githubusercontent.com/41671631/105658287-2c6ed880-5f01-11eb-8af6-daa6fd23576c.gif" width=500 height=500/>
-</div>
 
 ## Customize Appearance
 

--- a/lua/lspsaga/action.lua
+++ b/lua/lspsaga/action.lua
@@ -3,10 +3,10 @@ local action = {}
 
 -- direction must 1 or -1
 function action.smart_scroll_with_saga(direction)
-  local hover = require('lspsaga.hover')
-  local finder = require('lspsaga.provider')
-  local signature = require('lspsaga.signaturehelp')
-  local implement = require('lspsaga.implement')
+  local hover = require "lspsaga.hover"
+  local finder = require "lspsaga.provider"
+  local signature = require "lspsaga.signaturehelp"
+  local implement = require "lspsaga.implement"
 
   if hover.has_saga_hover() then
     hover.scroll_in_hover(direction)
@@ -18,17 +18,17 @@ function action.smart_scroll_with_saga(direction)
     implement.scroll_in_implement(direction)
   else
     local map = direction == 1 and "<C-f>" or "<C-b>"
-    local key = api.nvim_replace_termcodes(map,true,false,true)
-    api.nvim_feedkeys(key,'n',true)
+    local key = api.nvim_replace_termcodes(map, true, false, true)
+    api.nvim_feedkeys(key, "n", true)
   end
 end
 
-function action.scroll_in_win(win,direction,current_win_lnum,last_lnum,height)
+function action.scroll_in_win(win, direction, current_win_lnum, last_lnum, height)
   current_win_lnum = current_win_lnum
   if direction == 1 then
     current_win_lnum = current_win_lnum + height
     if current_win_lnum >= last_lnum then
-      current_win_lnum = last_lnum -1
+      current_win_lnum = last_lnum - 1
     end
   elseif direction == -1 then
     if current_win_lnum <= last_lnum and current_win_lnum > 0 then
@@ -41,7 +41,7 @@ function action.scroll_in_win(win,direction,current_win_lnum,last_lnum,height)
   if current_win_lnum <= 0 then
     current_win_lnum = 1
   end
-  api.nvim_win_set_cursor(win,{current_win_lnum,0})
+  api.nvim_win_set_cursor(win, { current_win_lnum, 0 })
   return current_win_lnum
 end
 

--- a/lua/lspsaga/api.lua
+++ b/lua/lspsaga/api.lua
@@ -1,0 +1,52 @@
+local M = {}
+
+M.methods = {
+  code_action = "textDocument/codeAction",
+}
+
+M.code_action_request = function(args)
+  local bufnr = vim.api.nvim_get_current_buf()
+  args.params.context = args.context or { diagnostics = vim.lsp.diagnostic.get_line_diagnostics() }
+  local callback = args.callback { bufnr = bufnr, method = M.methods.code_action, params = args.params }
+  vim.lsp.buf_request_all(bufnr, M.methods.code_action, args.params, callback)
+end
+
+local execute = function(client, action, ctx)
+  if action.edit then
+    vim.lsp.util.apply_workspace_edit(action.edit)
+  end
+
+  if action.command then
+    local command = type(action.command) == "table" and action.command or action
+    local fn = vim.lsp.commands[command.command]
+    if fn then
+      local enriched_ctx = vim.deepcopy(ctx)
+      enriched_ctx.client_id = client.id
+      fn(command, ctx)
+    else
+      vim.lsp.buf.execute_command(command)
+    end
+  end
+end
+
+M.code_action_execute = function(client_id, action, ctx)
+  local client = vim.lsp.get_client_by_id(client_id)
+  if
+    not action.edit
+    and client
+    and type(client.resolved_capabilities.code_action) == "table"
+    and client.resolved_capabilities.code_action.resolveProvider
+  then
+    client.request("codeAction/resolve", action, function(err, resolved_action)
+      if err then
+        vim.notify(err.code .. ": " .. err.message, vim.log.levels.ERROR)
+        return
+      end
+      execute(client, resolved_action, ctx)
+    end)
+  else
+    execute(client, action, ctx)
+  end
+end
+
+return M

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -1,295 +1,60 @@
-local api= vim.api
-local window = require('lspsaga.window')
-local config = require('lspsaga').config_values
-local wrap = require('lspsaga.wrap')
-local libs = require('lspsaga.libs')
+local wrap = require "lspsaga.wrap"
+local libs = require "lspsaga.libs"
+local window = require "lspsaga.codeaction.window"
+local api = require "lspsaga.api"
+local M = {}
 
-local Action = {}
-Action.__index = Action
+local on_code_action_response = function(ctx)
+  window.bufnr = vim.fn.bufnr()
+  window.ctx = ctx
+  window.content, window.actions = { window.title }, {}
 
-local get_namespace = function ()
-  return api.nvim_create_namespace('sagalightbulb')
-end
-
-local get_current_winid = function ()
-  return api.nvim_get_current_win()
-end
-
-local SIGN_GROUP = "sagalightbulb"
-local SIGN_NAME = "LspSagaLightBulb"
-
-if vim.tbl_isempty(vim.fn.sign_getdefined(SIGN_NAME)) then
-  vim.fn.sign_define(SIGN_NAME, { text = config.code_action_icon, texthl = "LspSagaLightBulbSign" })
-end
-
-local function _update_virtual_text(line)
-  local namespace = get_namespace()
-  api.nvim_buf_clear_namespace(0, namespace, 0, -1)
-
-  if line then
-    local icon_with_indent = '  ' .. config.code_action_icon
-    api.nvim_buf_set_extmark(0,namespace,line,-1,{
-        virt_text = { {icon_with_indent,'LspSagaLightBulb'} },
-        virt_text_pos = 'overlay',
-        hl_mode = "combine"
-      })
-  end
-end
-
-local function _update_sign(line)
-  local winid = get_current_winid()
-  if Action[winid] and Action[winid].lightbulb_line ~= 0 then
-    vim.fn.sign_unplace(
-      SIGN_GROUP, { id = Action[winid].lightbulb_line, buffer = "%" }
-    )
-  end
-
-  if line then
-    vim.fn.sign_place(
-      line, SIGN_GROUP, SIGN_NAME, "%",
-      { lnum = line + 1, priority = config.code_action_prompt.sign_priority }
-    )
-    Action[winid].lightbulb_line = line
-  end
-end
-
-local need_check_diagnostic = {
-  ['go'] = true,['python'] = true
-}
-
-function Action:render_action_virtual_text(line,diagnostics)
-  return function (_,_,actions)
-    if actions == nil or type(actions) ~= "table" or vim.tbl_isempty(actions) then
-      if config.code_action_prompt.virtual_text then
-        _update_virtual_text(nil)
-      end
-      if config.code_action_prompt.sign then
-        _update_sign(nil)
-      end
-    else
-      if config.code_action_prompt.sign then
-        if need_check_diagnostic[vim.bo.filetype] then
-          if next(diagnostics) == nil then
-            _update_sign(nil)
-          else
-            _update_sign(line)
-          end
-        else
-          _update_sign(line)
-        end
-      end
-
-      if config.code_action_prompt.virtual_text then
-        if need_check_diagnostic[vim.bo.filetype] then
-          if next(diagnostics) == nil then
-            _update_virtual_text(nil)
-          else
-            _update_virtual_text(line)
-          end
-        else
-          _update_virtual_text(line)
-        end
+  return function(response)
+    for client_id, result in pairs(response or {}) do
+      for index, action in ipairs(result.result or {}) do
+        table.insert(window.actions, { client_id, action })
+        table.insert(window.content, "[" .. index .. "]" .. " " .. action.title)
       end
     end
-  end
-end
 
-function Action:action_callback()
-  return function (_,_,response)
-    if response == nil or vim.tbl_isempty(response) then
-      print("No code actions available")
+    if #window.actions == 0 or #window.content == 1 then
+      vim.notify("No code actions available", vim.log.levels.INFO)
       return
     end
 
-    local contents = {}
-    local title = config['code_action_icon'] .. 'CodeActions:'
-    table.insert(contents,title)
+    table.insert(window.content, 2, wrap.add_truncate_line(window.content))
 
-    local from_other_servers = function()
-      local actions = {}
-      for _,action in pairs(response) do
-        self.actions[#self.actions+1] = action
-        local action_title = '['..#self.actions ..']' ..' '.. action.title
-        actions[#actions+1] = action_title
-      end
-      return actions
-    end
-
-    if self.actions and next(self.actions) ~= nil then
-      local other_actions = from_other_servers()
-      if next(other_actions) ~= nil then
-        vim.tbl_extend('force',self.actions,other_actions)
-      end
-      api.nvim_buf_set_option(self.action_bufnr,'modifiable',true)
-      vim.fn.append(vim.fn.line('$'),other_actions)
-      vim.cmd("resize "..#self.actions+2)
-      for i,_ in pairs(other_actions) do
-        vim.fn.matchadd('LspSagaCodeActionContent','\\%'.. #self.actions+1+i..'l')
-      end
-    else
-      self.actions = response
-      for index,action in pairs(response) do
-        local action_title = '['..index..']' ..' '.. action.title
-        table.insert(contents,action_title)
-      end
-    end
-
-    if #contents == 1 then return end
-
-    -- insert blank line
-    local truncate_line = wrap.add_truncate_line(contents)
-    table.insert(contents,2,truncate_line)
-
-    local content_opts = {
-      contents = contents,
-      filetype = 'LspSagaCodeAction',
+    window.open {
+      contents = window.content,
+      filetype = "LspSagaCodeAction",
       enter = true,
-      highlight = 'LspSagaCodeActionBorder'
+      highlight = "LspSagaCodeActionBorder",
     }
-
-    self.action_bufnr,self.action_winid = window.create_win_with_border(content_opts)
-    api.nvim_command('autocmd CursorMoved <buffer> lua require("lspsaga.codeaction").set_cursor()')
-    api.nvim_command("autocmd QuitPre <buffer> lua require('lspsaga.codeaction').quit_action_window()")
-
-    api.nvim_buf_add_highlight(self.action_bufnr,-1,"LspSagaCodeActionTitle",0,0,-1)
-    api.nvim_buf_add_highlight(self.action_bufnr,-1,"LspSagaCodeActionTruncateLine",1,0,-1)
-    for i=1,#contents-2,1 do
-      api.nvim_buf_add_highlight(self.action_bufnr,-1,"LspSagaCodeActionContent",1+i,0,-1)
-    end
-    self:apply_action_keys()
   end
 end
 
-local apply_keys = libs.apply_keys("codeaction")
-
-function Action:apply_action_keys()
-  local actions = {
-    ['quit_action_window'] = config.code_action_keys.quit,
-    ['do_code_action'] = config.code_action_keys.exec
+M.range_code_action = function(context, start_pos, end_pos)
+  local active, msg = libs.check_lsp_active()
+  if not active then
+    print(msg)
+    return
+  end
+  api.code_action_request {
+    params = vim.lsp.util.make_given_range_params(start_pos, end_pos),
+    context = context,
+    callback = on_code_action_response,
   }
-  for func, keys in pairs(actions) do
-    apply_keys(func, keys)
+end
+
+M.code_action = function()
+  local active, _ = libs.check_lsp_active()
+  if not active then
+    return
   end
+  api.code_action_request {
+    params = vim.lsp.util.make_range_params(),
+    callback = on_code_action_response,
+  }
 end
 
-local action_call_back = function (_,_)
-  return Action:action_callback()
-end
-
-local action_vritual_call_back = function (line,diagnostics)
-  return Action:render_action_virtual_text(line,diagnostics)
-end
-
-function Action:code_action(_call_back_fn,diagnostics)
-  local active,_ = libs.check_lsp_active()
-  if not active then return end
-  self.bufnr = vim.fn.bufnr()
-  local context =  { diagnostics = diagnostics }
-  local params = vim.lsp.util.make_range_params()
-  params.context = context
-  local line = params.range.start.line
-  local callback = _call_back_fn(line,diagnostics)
-  vim.lsp.buf_request(0,'textDocument/codeAction', params,callback)
-end
-
-function Action:range_code_action(context, start_pos, end_pos)
-  local active,msg = libs.check_lsp_active()
-  if not active then print(msg) return end
-
-  self.bufnr = vim.fn.bufnr()
-  vim.validate { context = { context, 't', true } }
-  context = context or { diagnostics = vim.lsp.diagnostic.get_line_diagnostics() }
-  local params = vim.lsp.util.make_given_range_params(start_pos, end_pos)
-  params.context = context
-  local call_back = self:action_callback()
-  vim.lsp.buf_request(0,'textDocument/codeAction', params,call_back)
-end
-
-function Action:set_cursor ()
-  local column = 2
-  local current_line = vim.fn.line('.')
-
-  if current_line == 1 then
-    vim.fn.cursor(3,column)
-  elseif current_line == 2 then
-    vim.fn.cursor(2+#self.actions,column)
-  elseif current_line == #self.actions + 3 then
-    vim.fn.cursor(3,column)
-  end
-end
-
-local function lsp_execute_command(bn,command)
-  vim.lsp.buf_request(bn,'workspace/executeCommand', command)
-end
-
-function Action:do_code_action()
-  local number = tonumber(vim.fn.expand("<cword>"))
-  local action = self.actions[number]
-
-  if action.edit or type(action.command) == "table" then
-    if action.edit then
-      vim.lsp.util.apply_workspace_edit(action.edit)
-    end
-    if type(action.command) == "table" then
-      lsp_execute_command(self.bufnr,action.command)
-    end
-  else
-    lsp_execute_command(self.bufnr,action)
-  end
-  self:quit_action_window()
-end
-
-function Action:clear_tmp_data()
-  self.actions = {}
-  self.bufnr = 0
-  self.action_bufnr = 0
-  self.action_winid = 0
-end
-
-function Action:quit_action_window ()
-  if self.action_bufnr == 0 and self.action_winid == 0 then return end
-  window.nvim_close_valid_window(self.action_winid)
-  self:clear_tmp_data()
-end
-
-local lspaction = {}
-
-local special_buffers = {
-  ['LspSagaCodeAction'] = true, ['lspsagafinder'] = true,['NvimTree'] = true,
-  ['vist'] = true,['lspinfo'] = true,['markdown'] = true,['text'] = true,
-}
-
-lspaction.code_action = function()
-  local diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
-  Action:code_action(action_call_back,diagnostics)
-end
-
-lspaction.code_action_prompt = function ()
-  if special_buffers[vim.bo.filetype] then return end
-  local active_lsp,_ = libs.check_lsp_active()
-  if not active_lsp then return end
-
-  local diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
-  local winid = get_current_winid()
-  Action[winid] = Action[winid] or {}
-  Action[winid].lightbulb_line = Action[winid].lightbulb_line or 0
-  Action:code_action(action_vritual_call_back,diagnostics)
-end
-
-lspaction.do_code_action = function ()
-  Action:do_code_action()
-end
-
-lspaction.quit_action_window = function()
-  Action:quit_action_window()
-end
-
-lspaction.range_code_action = function ()
-  Action:range_code_action()
-end
-
-lspaction.set_cursor = function ()
-  Action:set_cursor()
-end
-
-return lspaction
+return M

--- a/lua/lspsaga/codeaction/indicator.lua
+++ b/lua/lspsaga/codeaction/indicator.lua
@@ -1,0 +1,119 @@
+local M = { servers = {} }
+local _config = require("lspsaga").config_values
+local config = _config.code_action_prompt
+local icon = _config.code_action_icon
+local libs = require "lspsaga.libs"
+local window = require "lspsaga.codeaction.window"
+local api = require "lspsaga.api"
+
+M.group = "sagalightbulb"
+M.sign_name = "LspSagaLightBulb"
+
+if vim.tbl_isempty(vim.fn.sign_getdefined(M.sign_name)) then
+  vim.fn.sign_define(M.sign_name, { text = icon, texthl = "LspSagaLightBulbSign" })
+end
+
+M.require_diagnostics = {
+  ["go"] = true,
+  ["python"] = true,
+}
+
+M.special_buffers = {
+  ["LspSagaCodeAction"] = true,
+  ["lspsagafinder"] = true,
+  ["NvimTree"] = true,
+  ["vist"] = true,
+  ["lspinfo"] = true,
+  ["markdown"] = true,
+  ["text"] = true,
+}
+
+M.update = function(winid, line)
+  if config.virtual_text then
+    local namespace = vim.api.nvim_create_namespace "sagalightbulb"
+    vim.api.nvim_buf_clear_namespace(0, namespace, 0, -1)
+
+    if line then
+      vim.api.nvim_buf_set_extmark(0, namespace, line, -1, {
+        virt_text = { { "  " .. icon, M.sign_name } },
+        virt_text_pos = "overlay",
+        hl_mode = "combine",
+      })
+    end
+  end
+
+  if config.sign then
+    if not window[winid] then
+      return
+    end
+
+    if window[winid].lightbulb_line ~= 0 then
+      vim.fn.sign_unplace(M.group, { id = window[winid].lightbulb_line, buffer = "%" })
+    end
+
+    if line and window[winid] then
+      vim.fn.sign_place(line, M.group, M.sign_name, "%", {
+        lnum = line + 1,
+        priority = config.sign_priority,
+      })
+      window[winid].lightbulb_line = line
+    end
+  end
+end
+
+M.check = function()
+  local active, _ = libs.check_lsp_active()
+  local current_file = vim.fn.expand "%:p"
+
+  if M.servers[current_file] == nil then
+    local clients = vim.lsp.get_active_clients()
+    for _, client in ipairs(clients) do
+      if client.resolved_capabilities.code_actions then
+        M.servers[current_file] = true
+        break
+      end
+    end
+    if M.servers[current_file] == nil then
+      M.servers[current_file] = false
+    end
+  end
+
+  if M.special_buffers[vim.bo.filetype] or not active or M.servers[current_file] == false then
+    return
+  end
+
+  local winid = vim.api.nvim_get_current_win()
+  window[winid] = window[winid] or {}
+  window[winid].lightbulb_line = window[winid].lightbulb_line or 0
+
+  api.code_action_request {
+    params = vim.lsp.util.make_range_params(),
+    callback = function(ctx)
+      local line = ctx.params.range.start.line
+      local fail_to_have_diagnostics = M.require_diagnostics[vim.bo.filetype] and next(ctx.params.diagnostics) == nil
+      local no_action = true
+
+      return function(res)
+        for _, result in pairs(res) do
+          if result.result and next(result.result) ~= nil then
+            no_action = false
+            break
+          end
+        end
+
+        if no_action or fail_to_have_diagnostics then
+          return M.update(winid, nil)
+        else
+          return M.update(winid, line)
+        end
+      end
+    end,
+    winid = winid,
+  }
+end
+
+M.attach = function()
+  vim.cmd [[autocmd CursorHold,CursorHoldI * lua require'lspsaga.codeaction.indicator'.check()]]
+end
+
+return M

--- a/lua/lspsaga/codeaction/window.lua
+++ b/lua/lspsaga/codeaction/window.lua
@@ -1,0 +1,61 @@
+local config = require("lspsaga").config_values
+local window = require "lspsaga.window"
+local libs = require "lspsaga.libs"
+
+local api = require "lspsaga.api"
+local M = { title = config.code_action_icon .. "CodeActions:" }
+
+M.apply_keys = function()
+  libs.apply_keys("codeaction.window", {
+    ["close"] = config.code_action_keys.quit,
+    ["execute"] = config.code_action_keys.exec,
+  })
+end
+
+M.open = function(opts)
+  local cmd, hl = vim.api.nvim_command, vim.api.nvim_buf_add_highlight
+  M.action_bufnr, M.action_winid = window.create_win_with_border(opts)
+
+  cmd 'autocmd CursorMoved <buffer> lua require("lspsaga.codeaction.window").set_cursor()'
+  cmd "autocmd QuitPre <buffer> lua require('lspsaga.codeaction.window').close()"
+  hl(M.action_bufnr, -1, "LspSagaCodeActionTitle", 0, 0, -1)
+  hl(M.action_bufnr, -1, "LspSagaCodeActionTruncateLine", 1, 0, -1)
+
+  for i = 1, #M.content - 2, 1 do
+    hl(M.action_bufnr, -1, "LspSagaCodeActionContent", 1 + i, 0, -1)
+  end
+  M.apply_keys()
+end
+
+M.set_cursor = function()
+  local column = 2
+  local current_line = vim.fn.line "."
+
+  if current_line == 1 then
+    vim.fn.cursor(3, column)
+  elseif current_line == 2 then
+    vim.fn.cursor(2 + #M.actions, column)
+  elseif current_line == #M.actions + 3 then
+    vim.fn.cursor(3, column)
+  end
+end
+
+M.close = function()
+  if M.action_bufnr ~= 0 and M.action_winid ~= 0 then
+    window.nvim_close_valid_window(M.action_winid)
+    M.actions, M.bufnr, M.action_bufnr, M.action_winid, M.ctx = {}, 0, 0, 0, nil
+  end
+end
+
+M.execute = function()
+  local choice = M.actions[tonumber(vim.fn.expand "<cword>")]
+  if choice then
+    M.close()
+    local client_id, action = choice[1], choice[2]
+    api.code_action_execute(client_id, action, M.ctx)
+    return
+  end
+  M.close()
+end
+
+return M

--- a/lua/lspsaga/command.lua
+++ b/lua/lspsaga/command.lua
@@ -1,12 +1,12 @@
 local command = {}
-local provider = require('lspsaga.provider')
-local lsprename = require('lspsaga.rename')
-local lsphover = require('lspsaga.hover')
-local diagnostic = require('lspsaga.diagnostic')
-local codeaction = require('lspsaga.codeaction')
-local signature = require('lspsaga.signaturehelp')
-local floaterm = require('lspsaga.floaterm')
-local implement = require('lspsaga.implement')
+local provider = require "lspsaga.provider"
+local lsprename = require "lspsaga.rename"
+local lsphover = require "lspsaga.hover"
+local diagnostic = require "lspsaga.diagnostic"
+local codeaction = require "lspsaga.codeaction"
+local signature = require "lspsaga.signaturehelp"
+local floaterm = require "lspsaga.floaterm"
+local implement = require "lspsaga.implement"
 
 local subcommands = {
   lsp_finder = provider.lsp_finder,
@@ -15,8 +15,8 @@ local subcommands = {
   hover_doc = lsphover.render_hover_doc,
   show_cursor_diagnostics = diagnostic.show_cursor_diagnostics,
   show_line_diagnostics = diagnostic.show_line_diagnostics,
-  diagnostic_jump_next = diagnostic.lsp_jump_diagnostic_next,
-  diagnostic_jump_prev = diagnostic.lsp_jump_diagnostic_prev,
+  diagnostic_jump_next = diagnostic.navigate "next",
+  diagnostic_jump_prev = diagnostic.navigate "prev",
   code_action = codeaction.code_action,
   range_code_action = codeaction.range_code_action,
   signature_help = signature.signature_help,
@@ -29,8 +29,8 @@ function command.command_list()
   return vim.tbl_keys(subcommands)
 end
 
-function command.load_command(cmd,...)
-  local args = {...}
+function command.load_command(cmd, ...)
+  local args = { ... }
   if next(args) ~= nil then
     subcommands[cmd](args[1])
   else

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -1,71 +1,39 @@
 -- lsp dianostic
-local vim,api,lsp,util = vim,vim.api,vim.lsp,vim.lsp.util
-local window = require 'lspsaga.window'
-local libs = require('lspsaga.libs')
-local wrap = require 'lspsaga.wrap'
-local config = require('lspsaga').config_values
+local window = require "lspsaga.window"
+local libs = require "lspsaga.libs"
+local wrap = require "lspsaga.wrap"
+local config = require("lspsaga").config_values
 local if_nil = vim.F.if_nil
-local hover = require('lspsaga.hover')
+local hover = require "lspsaga.hover"
+local fmt = string.format
 local M = {}
 
-local function _iter_diagnostic_move_pos(name, opts, pos)
-  opts = opts or {}
+M.highlights = {
+  [vim.diagnostic.severity.ERROR] = "DiagnosticFloatingError",
+  [vim.diagnostic.severity.WARN] = "DiagnosticFloatingWarn",
+  [vim.diagnostic.severity.INFO] = "DiagnosticFloatingInfo",
+  [vim.diagnostic.severity.HINT] = "DiagnosticFloatingHint",
+}
 
-  local enable_popup = if_nil(opts.enable_popup, true)
-  local win_id = opts.win_id or vim.api.nvim_get_current_win()
-
-  if not pos then
-    print(string.format("%s: No more valid diagnostics to move to.", name))
-    return
-  end
-
-  vim.api.nvim_win_set_cursor(win_id, {pos[1] + 1, pos[2]})
-
-  if enable_popup then
-    vim.schedule(function()
-      M.show_line_diagnostics(opts.popup_opts, vim.api.nvim_win_get_buf(win_id))
-    end)
-  end
-end
-
-function M.lsp_jump_diagnostic_next(opts)
-  return _iter_diagnostic_move_pos(
-    "DiagnosticNext",
-    opts,
-    vim.lsp.diagnostic.get_next_pos(opts)
-  )
-end
-
-function M.lsp_jump_diagnostic_prev(opts)
-  return _iter_diagnostic_move_pos(
-    "DiagnosticPrevious",
-    opts,
-    vim.lsp.diagnostic.get_prev_pos(opts)
-  )
-end
-
-local function comp_severity_asc(diag1, diag2)
-  return diag1["severity"] < diag2["severity"]
-end
-
-local function show_diagnostics(opts, get_diagnostics)
+---TODO(refactor): move to popup.lua
+local show_diagnostics = function(opts, get_diagnostics)
   local close_hover = opts.close_hover or false
-
   -- if we have a hover rendered, don't show diagnostics due to this usually
   -- being bound to CursorHold which triggers after hover show
   if not close_hover and hover.has_saga_hover() then
     return
   end
 
-  local active,_ = libs.check_lsp_active()
-  if not active then return end
+  local active, _ = libs.check_lsp_active()
+  if not active then
+    return
+  end
   local max_width = window.get_max_float_width()
 
-  -- if there already has diagnostic float window did not show show lines
-  -- diagnostic window
-  local has_var, diag_float_winid = pcall(api.nvim_buf_get_var,0,"diagnostic_float_window")
+  -- if there already has diagnostic float window did not show show lines diagnostic window
+  local has_var, diag_float_winid = pcall(vim.api.nvim_buf_get_var, 0, "diagnostic_float_window")
   if has_var and diag_float_winid ~= nil then
-    if api.nvim_win_is_valid(diag_float_winid[1]) and api.nvim_win_is_valid(diag_float_winid[2]) then
+    if vim.api.nvim_win_is_valid(diag_float_winid[1]) and vim.api.nvim_win_is_valid(diag_float_winid[2]) then
       return
     end
   end
@@ -77,156 +45,140 @@ local function show_diagnostics(opts, get_diagnostics)
   local highlights = {}
   if show_header then
     lines[1] = config.dianostic_header_icon .. "Diagnostics:"
-    highlights[1] =  {0, "LspSagaDiagnosticHeader"}
+    highlights[1] = { 0, "LspSagaDiagnosticHeader" }
   end
 
   local diagnostics = get_diagnostics()
-  if vim.tbl_isempty(diagnostics) then return end
 
-  local sorted_diagnostics = severity_sort
-    and table.sort(diagnostics, comp_severity_asc)
-    or diagnostics
+  if vim.tbl_isempty(diagnostics) then
+    return
+  elseif severity_sort then
+    table.sort(diagnostics, function(a, b)
+      return a["severity"] < b["severity"]
+    end)
+  end
 
-  for i, diagnostic in ipairs(sorted_diagnostics) do
-    local prefix = config.prefix_diagnostic and string.format("%d. ", i) or ""
-    local hiname = lsp.diagnostic._get_floating_severity_highlight_name(diagnostic.severity)
-    assert(hiname, 'unknown severity: ' .. tostring(diagnostic.severity))
+  for i, diagnostic in ipairs(diagnostics) do
+    local prefix = config.prefix_diagnostic and string.format("%d. ", i) or ""  
+    local hiname = M.highlights[diagnostic.severity]
+    assert(hiname, "unknown severity: " .. tostring(diagnostic.severity))
 
-    local message_lines = vim.split(diagnostic.message, '\n', true)
-    table.insert(lines, prefix..message_lines[1])
-    table.insert(highlights, {#prefix + 1, hiname})
+    local message_lines = vim.split(diagnostic.message, "\n", true)
+    table.insert(lines, prefix .. message_lines[1])
+    table.insert(highlights, { #prefix + 1, hiname })
     if #message_lines[1] + 4 > max_width then
-      table.insert(highlights,{#prefix + 1, hiname})
+      table.insert(highlights, { #prefix + 1, hiname })
     end
     for j = 2, #message_lines do
-      table.insert(lines, '   '..message_lines[j])
-      table.insert(highlights, {0, hiname})
+      table.insert(lines, "   " .. message_lines[j])
+      table.insert(highlights, { 0, hiname })
     end
   end
 
-  local wrap_message = wrap.wrap_contents(lines,max_width,{
-    fill = true, pad_left = 3
-  })
+  local wrap_message = wrap.wrap_contents(lines, max_width, { fill = true, pad_left = 3 })
   if show_header then
     local truncate_line = wrap.add_truncate_line(wrap_message)
-    table.insert(wrap_message,2,truncate_line)
+    table.insert(wrap_message, 2, truncate_line)
   end
 
-  local content_opts = {
-    contents = wrap_message,
-    filetype = 'plaintext',
-    highlight = 'LspSagaDiagnosticBorder'
-  }
+  local content_opts = { contents = wrap_message, filetype = "plaintext", highlight = "LspSagaDiagnosticBorder" }
+  local bufnr, winid = window.create_win_with_border(content_opts, opts)
 
-  local bufnr,winid = window.create_win_with_border(content_opts,opts)
   for i, hi in ipairs(highlights) do
     local _, hiname = unpack(hi)
     -- Start highlight after the prefix
     if i == 1 then
-      api.nvim_buf_add_highlight(bufnr, -1, hiname, 0, 0, -1)
+      vim.api.nvim_buf_add_highlight(bufnr, -1, hiname, 0, 0, -1)
     else
-      api.nvim_buf_add_highlight(bufnr, -1, hiname, i, 3, -1)
+      vim.api.nvim_buf_add_highlight(bufnr, -1, hiname, i, 3, -1)
     end
   end
-  api.nvim_buf_add_highlight(bufnr,-1,'LspSagaDiagnosticTruncateLine',1,0,-1)
-  util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"}, winid)
-  api.nvim_win_set_var(0,"show_line_diag_winids",winid)
+
+  vim.api.nvim_buf_add_highlight(bufnr, -1, "LspSagaDiagnosticTruncateLine", 1, 0, -1)
+  vim.lsp.util.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, winid)
+  vim.api.nvim_win_set_var(0, "show_line_diag_winids", winid)
+
   return winid
 end
 
-local function get_diagnostic_start(diagnostic_entry)
-  local start_pos = diagnostic_entry["range"]["start"]
-  return start_pos["line"], start_pos["character"]
-end
-
-local function get_diagnostic_end(diagnostic_entry)
-  local end_pos = diagnostic_entry["range"]["end"]
-  return end_pos["line"], end_pos["character"]
-end
-
-local function in_range(cursor_line, cursor_char)
-  return function(diagnostic)
-    start_line, start_char = get_diagnostic_start(diagnostic)
-    end_line, end_char = get_diagnostic_end(diagnostic)
-
-    local one_line_diag = start_line == end_line
-
-    if one_line_diag and start_line == cursor_line then
-      if cursor_char >= start_char and cursor_char < end_char then
-        return true
-      end
-
-    -- multi line diagnostic
-    else
-      if cursor_line == start_line and cursor_char >= start_char then
-        return true
-      elseif cursor_line == end_line and cursor_char < end_char then
-        return true
-      elseif cursor_line > start_line and cursor_line < end_line  then
-        return true
-      end
-    end
-
-    return false
-  end
-end
-
-function M.show_cursor_diagnostics(opts, bufnr, client_id)
-  opts = opts or {}
-
-  local get_cursor_diagnostics = function()
-    bufnr = bufnr or 0
-
-    line_nr = vim.api.nvim_win_get_cursor(0)[1] - 1
-    column_nr = vim.api.nvim_win_get_cursor(0)[2]
+M.show_cursor_diagnostics = function(opts, bufnr)
+  return show_diagnostics(opts or {}, function()
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    local lnum, cnum = cursor[1] - 1, cursor[2]
 
     return vim.tbl_filter(
-      in_range(line_nr, column_nr), lsp.diagnostic.get(bufnr, client_id)
+      function(diagnostic)
+        local start_line, start_char = diagnostic['lnum'], diagnostic["col"]
+        local end_line, end_char = diagnostic["end_lnum"], diagnostic["end_col"]
+        local one_line_diag = start_line == end_line
+
+        if one_line_diag and start_line == lnum then
+          if cnum >= start_char and cnum < end_char then
+            return true
+          end
+          -- multi line diagnostic
+        else
+          if lnum == start_line and cnum >= start_char then
+            return true
+          elseif lnum == end_line and cnum < end_char then
+            return true
+          elseif lnum > start_line and lnum < end_line then
+            return true
+          end
+        end
+
+        return false
+      end,
+      vim.diagnostic.get(bufnr, {
+        lnum = lnum,
+      })
     )
-  end
-
-  return show_diagnostics(opts, get_cursor_diagnostics)
+  end)
 end
 
-function M.show_line_diagnostics(opts, bufnr, line_nr, client_id)
-  opts = opts or {}
-
-  local get_line_diagnostics = function()
-    bufnr = bufnr or 0
-    line_nr = line_nr or (vim.api.nvim_win_get_cursor(0)[1] - 1)
-
-    return lsp.diagnostic.get_line_diagnostics(bufnr, line_nr, opts, client_id)
-  end
-
-  return show_diagnostics(opts, get_line_diagnostics)
+M.show_line_diagnostics = function(opts, lnum, bufnr)
+  return show_diagnostics(opts or {}, function()
+    return vim.diagnostic.get(bufnr, { lnum = lnum or (vim.api.nvim_win_get_cursor(0)[1] - 1) })
+  end)
 end
 
-function M.lsp_diagnostic_sign(opts)
-  local group = {
-    err_group = {
-      highlight = 'LspDiagnosticsSignError',
-      sign =opts.error_sign
-    },
-    warn_group = {
-      highlight = 'LspDiagnosticsSignWarning',
-      sign =opts.warn_sign
-    },
-    hint_group = {
-      highlight = 'LspDiagnosticsSignHint',
-      sign =opts.hint_sign
-    },
-    infor_group = {
-      highlight = 'LspDiagnosticsSignInformation',
-      sign =opts.infor_sign
-    },
-  }
+M.navigate = function(direction)
+  return function(opts)
+    opts = opts or {}
+    local pos = vim.diagnostic[fmt("get_%s_pos", direction)](opts)
+    if not pos then
+      --- TODO: move to notify.lua, notify.diagnostics.no_more_diagnostics(direction:gsub("^%l", string.upper)))
+      return print(fmt("Diagnostic%s: No more valid diagnostics to move to.", direction:gsub("^%l", string.upper)))
+    end
 
-  for _,g in pairs(group) do
-    vim.fn.sign_define(
-    g.highlight,
-    {text=g.sign,texthl=g.highlight,linehl='',numhl=''}
-    )
+    local win_id = opts.win_id or vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_cursor(win_id, { pos[1] + 1, pos[2] })
+
+    vim.schedule(function()
+      M.show_line_diagnostics(opts.popup_opts, nil, vim.api.nvim_win_get_buf(win_id))
+    end)
   end
 end
+
+--- TODO: at some point just use builtin function to preview diagnostics
+--- Missing borders and formating of title
+-- vim.diagnostic.show_position_diagnostics {
+--   focusable = false,
+--   close_event = { "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" },
+--   source = false,
+--   show_header = true,
+--   border = "rounded",
+--   format = function(info)
+--     local lines = {}
+--     if config.diagnostic_show_source then
+--       lines[#lines + 1] = info.source:gsub("%.", ":")
+--     end
+--     lines[#lines + 1] = info.message
+--     if config.diagnostic_show_code then
+--       lines[#lines + 1] = fmt("(%s)", info.user_data.lsp.code)
+--     end
+--     return table.concat(lines, " ")
+--   end,
+-- }
 
 return M

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -88,7 +88,7 @@ local function show_diagnostics(opts, get_diagnostics)
     or diagnostics
 
   for i, diagnostic in ipairs(sorted_diagnostics) do
-    local prefix = string.format("%d. ", i)
+    local prefix = config.prefix_diagnostic and string.format("%d. ", i) or ""
     local hiname = lsp.diagnostic._get_floating_severity_highlight_name(diagnostic.severity)
     assert(hiname, 'unknown severity: ' .. tostring(diagnostic.severity))
 
@@ -107,8 +107,10 @@ local function show_diagnostics(opts, get_diagnostics)
   local wrap_message = wrap.wrap_contents(lines,max_width,{
     fill = true, pad_left = 3
   })
-  local truncate_line = wrap.add_truncate_line(wrap_message)
-  table.insert(wrap_message,2,truncate_line)
+  if show_header then
+    local truncate_line = wrap.add_truncate_line(wrap_message)
+    table.insert(wrap_message,2,truncate_line)
+  end
 
   local content_opts = {
     contents = wrap_message,

--- a/lua/lspsaga/floaterm.lua
+++ b/lua/lspsaga/floaterm.lua
@@ -1,13 +1,13 @@
 local api = vim.api
-local window = require 'lspsaga.window'
+local window = require "lspsaga.window"
 
-local function open_float_terminal(command,border_style)
-  local cmd = command or ''
+local function open_float_terminal(command, border_style)
+  local cmd = command or ""
   border_style = border_style or 0
 
   -- get dimensions
-  local width = api.nvim_get_option("columns")
-  local height = api.nvim_get_option("lines")
+  local width = api.nvim_get_option "columns"
+  local height = api.nvim_get_option "lines"
 
   -- calculate our floating window size
   local win_height = math.ceil(height * 0.8)
@@ -29,39 +29,42 @@ local function open_float_terminal(command,border_style)
 
   local content_opts = {
     contents = {},
-    filetype = 'Floaterm',
-    enter = true
+    filetype = "Floaterm",
+    enter = true,
   }
 
-  local cb,cw,ow
+  local cb, cw, ow
   if border_style == 0 then
-    cb,cw,_,ow = window.open_shadow_float_win(content_opts,opts)
+    cb, cw, _, ow = window.open_shadow_float_win(content_opts, opts)
   else
     local border_opts = {
-      border = border_style
+      border = border_style,
     }
-    cb,cw,_,ow = window.create_win_with_border(content_opts,opts)
+    cb, cw, _, ow = window.create_win_with_border(content_opts, opts)
   end
-  api.nvim_command('terminal '..cmd)
-  api.nvim_command('setlocal nobuflisted')
-  api.nvim_command('startinsert!')
-  api.nvim_buf_set_var(cb,'float_terminal_win',{cw,ow})
+  api.nvim_command("terminal " .. cmd)
+  api.nvim_command "setlocal nobuflisted"
+  api.nvim_command "startinsert!"
+  api.nvim_buf_set_var(cb, "float_terminal_win", { cw, ow })
 end
 
 local function close_float_terminal()
-  local has_var,float_terminal_win = pcall(api.nvim_buf_get_var,0,'float_terminal_win')
-  if not has_var then return end
-  if float_terminal_win[1] ~= nil and
-    api.nvim_win_is_valid(float_terminal_win[1]) and
-    float_terminal_win[2] ~= nil and
-    api.nvim_win_is_valid(float_terminal_win[2])
+  local has_var, float_terminal_win = pcall(api.nvim_buf_get_var, 0, "float_terminal_win")
+  if not has_var then
+    return
+  end
+  if
+    float_terminal_win[1] ~= nil
+    and api.nvim_win_is_valid(float_terminal_win[1])
+    and float_terminal_win[2] ~= nil
+    and api.nvim_win_is_valid(float_terminal_win[2])
   then
-    api.nvim_win_close(float_terminal_win[1],true)
-    api.nvim_win_close(float_terminal_win[2],true)
+    api.nvim_win_close(float_terminal_win[1], true)
+    api.nvim_win_close(float_terminal_win[2], true)
   end
 end
 
 return {
   open_float_terminal = open_float_terminal,
-  close_float_terminal = close_float_terminal
+  close_float_terminal = close_float_terminal,
 }

--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -1,12 +1,12 @@
-local api,lsp,util = vim.api,vim.lsp,vim.lsp.util
-local window = require('lspsaga.window')
-local action = require('lspsaga.action')
+local api, lsp, util = vim.api, vim.lsp, vim.lsp.util
+local window = require "lspsaga.window"
+local action = require "lspsaga.action"
 local npcall = vim.F.npcall
 local hover = {}
 
 local function focusable_float(unique_name, fn)
   if npcall(api.nvim_win_get_var, 0, unique_name) then
-    return api.nvim_command("wincmd p")
+    return api.nvim_command "wincmd p"
   end
   local bufnr = api.nvim_get_current_buf()
   local pbufnr, pwinnr = fn()
@@ -16,17 +16,26 @@ local function focusable_float(unique_name, fn)
   end
 end
 
-hover.handler = function(_, method, result)
-  focusable_float(method, function()
-    if not (result and result.contents) then return end
+hover.handler = function(_, result, ctx, _)
+  focusable_float(ctx.method, function()
+    if not (result and result.contents) then
+      return
+    end
     local markdown_lines = lsp.util.convert_input_to_markdown_lines(result.contents)
     markdown_lines = lsp.util.trim_empty_lines(markdown_lines)
-    if vim.tbl_isempty(markdown_lines) then return end
+    if vim.tbl_isempty(markdown_lines) then
+      return
+    end
     window.nvim_win_try_close()
-    local bufnr,winid = window.fancy_floating_markdown(markdown_lines)
+    local bufnr, winid = window.fancy_floating_markdown(markdown_lines)
 
-    lsp.util.close_preview_autocmd({"CursorMoved", "BufHidden","BufLeave", "InsertCharPre"}, winid)
-    return bufnr,winid
+    lsp.util.close_preview_autocmd({
+      "CursorMoved",
+      "BufHidden",
+      "BufLeave",
+      "InsertCharPre",
+    }, winid)
+    return bufnr, winid
   end)
 end
 
@@ -34,12 +43,14 @@ function hover.render_hover_doc()
   --if has diagnostic window close
   window.nvim_win_try_close()
   local params = util.make_position_params()
-  vim.lsp.buf_request(0,'textDocument/hover', params, hover.handler)
+  vim.lsp.buf_request(0, "textDocument/hover", params, hover.handler)
 end
 
 function hover.has_saga_hover()
-  local has_hover_win,datas = pcall(api.nvim_win_get_var,0,'lspsaga_hoverwin_data')
-  if not has_hover_win then return false end
+  local has_hover_win, datas = pcall(api.nvim_win_get_var, 0, "lspsaga_hoverwin_data")
+  if not has_hover_win then
+    return false
+  end
   if api.nvim_win_is_valid(datas[1]) then
     return true
   end
@@ -48,19 +59,23 @@ end
 
 function hover.close_hover_window()
   if hover.has_saga_hover() then
-    local data = npcall(api.nvim_win_get_var,0,'lspsaga_hoverwin_data')
-    api.nvim_win_close(data[1],true)
+    local data = npcall(api.nvim_win_get_var, 0, "lspsaga_hoverwin_data")
+    api.nvim_win_close(data[1], true)
   end
 end
 
 -- 1 mean down -1 mean up
 function hover.scroll_in_hover(direction)
-  local has_hover_win,hover_data = pcall(api.nvim_win_get_var,0,'lspsaga_hoverwin_data')
-  if not has_hover_win then return end
-  local hover_win,height,current_win_lnum,last_lnum = hover_data[1],hover_data[2],hover_data[3],hover_data[4]
-  if not api.nvim_win_is_valid(hover_win) then return end
-  current_win_lnum = action.scroll_in_win(hover_win,direction,current_win_lnum,last_lnum,height)
-  api.nvim_win_set_var(0,'lspsaga_hoverwin_data',{hover_win,height,current_win_lnum,last_lnum})
+  local has_hover_win, hover_data = pcall(api.nvim_win_get_var, 0, "lspsaga_hoverwin_data")
+  if not has_hover_win then
+    return
+  end
+  local hover_win, height, current_win_lnum, last_lnum = hover_data[1], hover_data[2], hover_data[3], hover_data[4]
+  if not api.nvim_win_is_valid(hover_win) then
+    return
+  end
+  current_win_lnum = action.scroll_in_win(hover_win, direction, current_win_lnum, last_lnum, height)
+  api.nvim_win_set_var(0, "lspsaga_hoverwin_data", { hover_win, height, current_win_lnum, last_lnum })
 end
 
 return hover

--- a/lua/lspsaga/implement.lua
+++ b/lua/lspsaga/implement.lua
@@ -1,29 +1,34 @@
-local lsp,api = vim.lsp,vim.api
-local config = require('lspsaga').config_values
-local window = require('lspsaga.window')
-local libs = require('lspsaga.libs')
-local action = require('lspsaga.action')
+local lsp, api = vim.lsp, vim.api
+local config = require("lspsaga").config_values
+local window = require "lspsaga.window"
+local libs = require "lspsaga.libs"
+local action = require "lspsaga.action"
 local implement = {}
 
 function implement.lspsaga_implementation(timeout_ms)
-  local active,msg = libs.check_lsp_active()
-  if not active then print(msg) return end
+  local active, msg = libs.check_lsp_active()
+  if not active then
+    print(msg)
+    return
+  end
 
   local method = "textDocument/implementation"
   local params = lsp.util.make_position_params()
-  local result = vim.lsp.buf_request_sync(0,method,params,timeout_ms or 1000)
+  local result = vim.lsp.buf_request_sync(0, method, params, timeout_ms or 1000)
   if result == nil or vim.tbl_isempty(result) then
     print("No location found: " .. method)
     return nil
   end
-  result = {vim.tbl_deep_extend("force", {}, unpack(result))}
+  result = { vim.tbl_deep_extend("force", {}, unpack(result)) }
 
   if vim.tbl_islist(result) and not vim.tbl_isempty(result[1]) then
     local uri = result[1].result[1].uri or result[1].result[1].targetUri
-    if #uri == 0 then return end
+    if #uri == 0 then
+      return
+    end
     local bufnr = vim.uri_to_bufnr(uri)
     if not vim.api.nvim_buf_is_loaded(bufnr) then
-        vim.fn.bufload(bufnr)
+      vim.fn.bufload(bufnr)
     end
     local range = result[1].result[1].targetRange or result[1].result[1].range
     local start_line = 0
@@ -33,10 +38,13 @@ function implement.lspsaga_implementation(timeout_ms)
       start_line = range.start.line
     end
 
-    local content =
-        vim.api.nvim_buf_get_lines(bufnr, start_line, range["end"].line + 1 +
-        config.max_preview_lines, false)
-    content = vim.list_extend({config.definition_preview_icon.."Lsp Implements",""},content)
+    local content = vim.api.nvim_buf_get_lines(
+      bufnr,
+      start_line,
+      range["end"].line + 1 + config.max_preview_lines,
+      false
+    )
+    content = vim.list_extend({ config.definition_preview_icon .. "Lsp Implements", "" }, content)
     local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
 
     local opts = {
@@ -56,18 +64,19 @@ function implement.lspsaga_implementation(timeout_ms)
       filetype = filetype,
     }
 
-    local bf,wi = window.create_win_with_border(content_opts,opts)
-    vim.lsp.util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"},
-                                        wi)
-    vim.api.nvim_buf_add_highlight(bf,-1,"DefinitionPreviewTitle",0,0,-1)
+    local bf, wi = window.create_win_with_border(content_opts, opts)
+    vim.lsp.util.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, wi)
+    vim.api.nvim_buf_add_highlight(bf, -1, "DefinitionPreviewTitle", 0, 0, -1)
 
-    api.nvim_buf_set_var(0,'lspsaga_implement_preview',{wi,1,config.max_preview_lines,10})
+    api.nvim_buf_set_var(0, "lspsaga_implement_preview", { wi, 1, config.max_preview_lines, 10 })
   end
 end
 
 function implement.has_implement_win()
-  local has_win,data = pcall(api.nvim_buf_get_var,0,'lspsaga_implement_preview')
-  if not has_win then return false end
+  local has_win, data = pcall(api.nvim_buf_get_var, 0, "lspsaga_implement_preview")
+  if not has_win then
+    return false
+  end
   if api.nvim_win_is_valid(data[1]) then
     return true
   end
@@ -75,11 +84,15 @@ function implement.has_implement_win()
 end
 
 function implement.scroll_in_implement(direction)
-  local has_hover_win,data = pcall(api.nvim_win_get_var,0,'lspsaga_implement_preview')
-  if not has_hover_win then return end
-  local hover_win,height,current_win_lnum,last_lnum = data[1],data[2],data[3],data[4]
-  if not api.nvim_win_is_valid(hover_win) then return end
-  current_win_lnum = action.scroll_in_win(hover_win,direction,current_win_lnum,last_lnum,height)
-  api.nvim_win_set_var(0,'lspsaga_implement_preview',{hover_win,height,current_win_lnum,last_lnum})
+  local has_hover_win, data = pcall(api.nvim_win_get_var, 0, "lspsaga_implement_preview")
+  if not has_hover_win then
+    return
+  end
+  local hover_win, height, current_win_lnum, last_lnum = data[1], data[2], data[3], data[4]
+  if not api.nvim_win_is_valid(hover_win) then
+    return
+  end
+  current_win_lnum = action.scroll_in_win(hover_win, direction, current_win_lnum, last_lnum, height)
+  api.nvim_win_set_var(0, "lspsaga_implement_preview", { hover_win, height, current_win_lnum, last_lnum })
 end
 return implement

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -33,7 +33,8 @@ saga.config_values = {
   definition_preview_icon = '  ',
   border_style = "single",
   rename_prompt_prefix = '➤',
-  server_filetype_map = {}
+  server_filetype_map = {},
+  prefix_diagnostic = true
 }
 
 local extend_config = function(opts)

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -4,49 +4,65 @@ saga.config_values = {
   debug = false,
   use_saga_diagnostic_sign = true,
   -- diagnostic sign
-  error_sign = '',
-  warn_sign = '',
-  hint_sign = '',
-  infor_sign = '',
-  dianostic_header_icon = '   ',
+  error_sign = "",
+  warn_sign = "",
+  hint_sign = "",
+  infor_sign = "",
+  diagnostic_header_icon = "   ",
+  -- diagnostic_show_source = true,
+  -- diagnostic_show_code = true,
   -- code action title icon
-  code_action_icon = ' ',
+  code_action_icon = " ",
   code_action_prompt = {
     enable = true,
     sign = true,
     sign_priority = 40,
     virtual_text = true,
   },
-  finder_definition_icon = '  ',
-  finder_reference_icon = '  ',
+  finder_definition_icon = "  ",
+  finder_reference_icon = "  ",
   max_preview_lines = 10,
   finder_action_keys = {
-    open = 'o', vsplit = 's',split = 'i',quit = 'q',
-    scroll_down = '<C-f>',scroll_up = '<C-b>'
+    open = "o",
+    vsplit = "s",
+    split = "i",
+    quit = "q",
+    scroll_down = "<C-f>",
+    scroll_up = "<C-b>",
   },
   code_action_keys = {
-    quit = 'q',exec = '<CR>'
+    quit = "q",
+    exec = "<CR>",
   },
   rename_action_keys = {
-    quit = '<C-c>',exec = '<CR>'
+    quit = "<C-c>",
+    exec = "<CR>",
   },
-  definition_preview_icon = '  ',
+  definition_preview_icon = "  ",
   border_style = "single",
-  rename_prompt_prefix = '➤',
+  rename_prompt_prefix = "➤",
   server_filetype_map = {},
-  prefix_diagnostic = true
+  prefix_diagnostic = true.
 }
+
+saga.config_values.dianostic_header_icon = saga.config_values.diagnostic_header_icon
 
 local extend_config = function(opts)
   opts = opts or {}
-  if next(opts) == nil then return  end
-  for key,value in pairs(opts) do
+  if next(opts) == nil then
+    return
+  end
+  for key, value in pairs(opts) do
     if saga.config_values[key] == nil then
-      error(string.format('[LspSaga] Key %s not exist in config values',key))
+      error(string.format("[LspSaga] Key %s not exist in config values", key))
       return
     end
-    if type(saga.config_values[key]) == 'table' then
-      for k,v in pairs(value) do
+    if key == "dianostic_header_icon" then
+      --- TODO: remove
+      print "dianostic_header_icon will be depericated soon due to miss-spelling. use 'diagnostic_header_icon'"
+    end
+    if type(saga.config_values[key]) == "table" then
+      for k, v in pairs(value) do
         saga.config_values[key][k] = v
       end
     else
@@ -55,16 +71,31 @@ local extend_config = function(opts)
   end
 end
 
-function saga.init_lsp_saga(opts)
+saga.init_lsp_saga = function(opts)
   extend_config(opts)
-  local diagnostic = require 'lspsaga.diagnostic'
+  local config = saga.config_values
 
-  if saga.config_values.use_saga_diagnostic_sign then
-    diagnostic.lsp_diagnostic_sign(saga.config_values)
+  if config.use_saga_diagnostic_sign then
+    for type, icon in pairs {
+      Error = config.error_sign,
+      Warn = config.warn_sign,
+      Hint = config.hint_sign,
+      Info = config.infor_sign,
+    } do
+      local hl = "DiagnosticSign" .. type
+      vim.fn.sign_define(hl, {
+        text = icon,
+        texthl = hl,
+        numhl = "",
+      })
+    end
   end
-  if saga.config_values.code_action_prompt.enable then
-    vim.cmd [[autocmd CursorHold,CursorHoldI * lua require'lspsaga.codeaction'.code_action_prompt()]]
+
+  if config.code_action_prompt.enable then
+    require("lspsaga.codeaction.indicator").attach()
   end
 end
+
+saga.setup = saga.init_lsp_saga
 
 return saga

--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -1,23 +1,23 @@
 local api = vim.api
 local libs = {}
-local server_filetype_map = require('lspsaga').config_values.server_filetype_map
+local server_filetype_map = require("lspsaga").config_values.server_filetype_map
 
 function libs.is_windows()
   return vim.loop.os_uname().sysname:find("Windows", 1, true) and true
 end
 
-local path_sep = libs.is_windows() and '\\' or '/'
+local path_sep = libs.is_windows() and "\\" or "/"
 
 function libs.get_home_dir()
   if libs.is_windows() then
-    return os.getenv("USERPROFILE")
+    return os.getenv "USERPROFILE"
   end
-  return os.getenv("HOME")
+  return os.getenv "HOME"
 end
 
 -- check index in table
-function libs.has_key (tab,idx)
-  for index,_ in pairs(tab) do
+function libs.has_key(tab, idx)
+  for index, _ in pairs(tab) do
     if index == idx then
       return true
     end
@@ -25,8 +25,8 @@ function libs.has_key (tab,idx)
   return false
 end
 
-function libs.has_value(tbl,val)
-  for _,v in pairs(tbl)do
+function libs.has_value(tbl, val)
+  for _, v in pairs(tbl) do
     if v == val then
       return true
     end
@@ -34,40 +34,40 @@ function libs.has_value(tbl,val)
   return false
 end
 
-function libs.nvim_create_augroup(group_name,definitions)
-  vim.api.nvim_command('augroup '..group_name)
-  vim.api.nvim_command('autocmd!')
+function libs.nvim_create_augroup(group_name, definitions)
+  vim.api.nvim_command("augroup " .. group_name)
+  vim.api.nvim_command "autocmd!"
   for _, def in ipairs(definitions) do
-    local command = table.concat(vim.tbl_flatten{'autocmd', def}, ' ')
+    local command = table.concat(vim.tbl_flatten { "autocmd", def }, " ")
     vim.api.nvim_command(command)
   end
-  vim.api.nvim_command('augroup END')
+  vim.api.nvim_command "augroup END"
 end
 
-function libs.nvim_create_keymap(definitions,lhs)
+function libs.nvim_create_keymap(definitions, lhs)
   for _, def in pairs(definitions) do
     local bufnr = def[1]
     local mode = def[2]
     local key = def[3]
     local rhs = def[4]
-    api.nvim_buf_set_keymap(bufnr,mode,key,rhs,lhs)
+    api.nvim_buf_set_keymap(bufnr, mode, key, rhs, lhs)
   end
 end
 
 function libs.check_lsp_active()
   local active_clients = vim.lsp.get_active_clients()
   if next(active_clients) == nil then
-    return false,'[lspsaga] No lsp client available'
+    return false, "[lspsaga] No lsp client available"
   end
-  return true,nil
+  return true, nil
 end
 
 function libs.result_isempty(res)
   if type(res) ~= "table" then
-    print('[Lspsaga] Server return wrong response')
+    print "[Lspsaga] Server return wrong response"
     return
   end
-  for _,v in pairs(res) do
+  for _, v in pairs(res) do
     if next(v) == nil then
       return true
     end
@@ -81,15 +81,15 @@ function libs.result_isempty(res)
   return false
 end
 
-function libs.split_by_pathsep(text,start_pos)
-  local pattern = libs.is_windows() and path_sep or '/'..path_sep
-  local short_text = ''
+function libs.split_by_pathsep(text, start_pos)
+  local pattern = libs.is_windows() and path_sep or "/" .. path_sep
+  local short_text = ""
   local split_table = {}
-  for word in text:gmatch('[^'..pattern..']+') do
-    table.insert(split_table,word)
+  for word in text:gmatch("[^" .. pattern .. "]+") do
+    table.insert(split_table, word)
   end
 
-  for i = start_pos,#split_table,1 do
+  for i = start_pos, #split_table, 1 do
     short_text = short_text .. split_table[i]
     if i ~= #split_table then
       short_text = short_text .. path_sep
@@ -99,13 +99,16 @@ function libs.split_by_pathsep(text,start_pos)
 end
 
 function libs.get_lsp_root_dir()
-  local active,msg = libs.check_lsp_active()
-  if not active then print(msg) return end
+  local active, msg = libs.check_lsp_active()
+  if not active then
+    print(msg)
+    return
+  end
   local clients = vim.lsp.get_active_clients()
-  for _,client in pairs(clients) do
-    if (client.config.filetypes and client.config.root_dir) then
+  for _, client in pairs(clients) do
+    if client.config.filetypes and client.config.root_dir then
       if type(client.config.filetypes) == "table" then
-        if libs.has_value(client.config.filetypes,vim.bo.filetype) then
+        if libs.has_value(client.config.filetypes, vim.bo.filetype) then
           return client.config.root_dir
         end
       elseif type(client.config.filetypes) == "string" then
@@ -114,26 +117,33 @@ function libs.get_lsp_root_dir()
         end
       end
     else
-      for name,fts in pairs(server_filetype_map) do
+      for name, fts in pairs(server_filetype_map) do
         for _, ft in pairs(fts) do
-          if (ft == vim.bo.filetype and client.config.name == name and client.config.root_dir) then
+          if ft == vim.bo.filetype and client.config.name == name and client.config.root_dir then
             return client.config.root_dir
           end
         end
       end
     end
   end
-  return ''
+  return ""
 end
 
-function libs.apply_keys(ns)
-  return function(func, keys)
-    keys = type(keys) == "string" and {keys} or keys
+function libs.apply_keys(ns, actions)
+  local map = function(func, keys)
+    keys = type(keys) == "string" and { keys } or keys
     local fmt = "nnoremap <buffer><nowait><silent>%s <cmd>lua require('lspsaga.%s').%s()<CR>"
 
     vim.tbl_map(function(key)
       api.nvim_command(string.format(fmt, key, ns, func))
     end, keys)
+  end
+  if actions then
+    for func, keys in pairs(actions) do
+      map(func, keys)
+    end
+  else
+    return map
   end
 end
 

--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -1,15 +1,15 @@
-local window = require 'lspsaga.window'
-local vim,api,lsp,vfn = vim,vim.api,vim.lsp,vim.fn
-local config = require('lspsaga').config_values
-local libs = require('lspsaga.libs')
+local window = require "lspsaga.window"
+local vim, api, lsp, vfn = vim, vim.api, vim.lsp, vim.fn
+local config = require("lspsaga").config_values
+local libs = require "lspsaga.libs"
 local home_dir = libs.get_home_dir()
-local scroll_in_win = require('lspsaga.action').scroll_in_win
+local scroll_in_win = require("lspsaga.action").scroll_in_win
 
 local send_request = function(timeout)
-  local method = {"textDocument/definition","textDocument/references"}
+  local method = { "textDocument/definition", "textDocument/references" }
   local def_params = lsp.util.make_position_params()
   local ref_params = lsp.util.make_position_params()
-  ref_params.context = {includeDeclaration = true;}
+  ref_params.context = { includeDeclaration = true }
   local def_response = lsp.buf_request_sync(0, method[1], def_params, timeout or 1000)
   local ref_response = lsp.buf_request_sync(0, method[2], ref_params, timeout or 1000)
   if config.debug then
@@ -21,22 +21,22 @@ local send_request = function(timeout)
   if libs.result_isempty(def_response) then
     def_response[1] = {}
     def_response[1].result = {}
-    def_response[1].result.saga_msg = '0 definitions found'
+    def_response[1].result.saga_msg = "0 definitions found"
   end
-  table.insert(responses,def_response)
+  table.insert(responses, def_response)
 
   if libs.result_isempty(ref_response) then
     ref_response[1] = {}
     ref_response[1].result = {}
-    ref_response[1].result.saga_msg = '0 references found'
+    ref_response[1].result.saga_msg = "0 references found"
   end
-  table.insert(responses,ref_response)
+  table.insert(responses, ref_response)
 
-  for i,response in ipairs(responses) do
+  for i, response in ipairs(responses) do
     if type(response) == "table" then
-      for _,res in pairs(response) do
+      for _, res in pairs(response) do
         if res.result then
-          coroutine.yield(res.result,i)
+          coroutine.yield(res.result, i)
         end
       end
     end
@@ -51,7 +51,7 @@ function Finder:lsp_finder_request()
   return uv.new_async(vim.schedule_wrap(function()
     local root_dir = libs.get_lsp_root_dir()
     if string.len(root_dir) == 0 then
-      print('[LspSaga] get root dir failed')
+      print "[LspSaga] get root dir failed"
       return
     end
     self.WIN_WIDTH = vim.fn.winwidth(0)
@@ -62,12 +62,12 @@ function Finder:lsp_finder_request()
     self.reference_uri = 0
 
     local request_intance = coroutine.create(send_request)
-    self.buf_filetype = api.nvim_buf_get_option(0,'filetype')
+    self.buf_filetype = api.nvim_buf_get_option(0, "filetype")
     while true do
-      local _,result,method_type = coroutine.resume(request_intance)
-      self:create_finder_contents(result,method_type,root_dir)
+      local _, result, method_type = coroutine.resume(request_intance)
+      self:create_finder_contents(result, method_type, root_dir)
 
-      if coroutine.status(request_intance) == 'dead' then
+      if coroutine.status(request_intance) == "dead" then
         break
       end
     end
@@ -75,42 +75,42 @@ function Finder:lsp_finder_request()
   end))
 end
 
-function Finder:create_finder_contents(result,method_type,root_dir)
+function Finder:create_finder_contents(result, method_type, root_dir)
   local target_lnum = 0
-  if type(result) == 'table' then
+  if type(result) == "table" then
     local method_option = {
-      {icon = config.finder_definition_icon,title = ':  '.. #result ..' Definitions'};
-      {icon = config.finder_reference_icon,title = ':  '.. #result ..' References',};
+      { icon = config.finder_definition_icon, title = ":  " .. #result .. " Definitions" },
+      { icon = config.finder_reference_icon, title = ":  " .. #result .. " References" },
     }
-    local params = vim.fn.expand("<cword>")
+    local params = vim.fn.expand "<cword>"
     self.param_length = #params
-    local title = method_option[method_type].icon.. params ..method_option[method_type].title
+    local title = method_option[method_type].icon .. params .. method_option[method_type].title
 
     if method_type == 1 then
       self.definition_uri = result.saga_msg and 1 or #result
-      table.insert(self.contents,title)
+      table.insert(self.contents, title)
       target_lnum = 2
       if result.saga_msg then
-        table.insert(self.contents," ")
-        table.insert(self.contents,'[1] ' .. result.saga_msg)
+        table.insert(self.contents, " ")
+        table.insert(self.contents, "[1] " .. result.saga_msg)
         return
       end
     else
       self.reference_uri = result.saga_msg and 1 or #result
       target_lnum = target_lnum + self.definition_uri + 5
-      table.insert(self.contents," ")
-      table.insert(self.contents,title)
+      table.insert(self.contents, " ")
+      table.insert(self.contents, title)
       if result.saga_msg then
-        table.insert(self.contents," ")
-        table.insert(self.contents,'[1] ' .. result.saga_msg)
+        table.insert(self.contents, " ")
+        table.insert(self.contents, "[1] " .. result.saga_msg)
         return
       end
     end
 
-    for index,_ in ipairs(result) do
+    for index, _ in ipairs(result) do
       local uri = result[index].targetUri or result[index].uri
       if uri == nil then
-          return
+        return
       end
       local bufnr = vim.uri_to_bufnr(uri)
       if not api.nvim_buf_is_loaded(bufnr) then
@@ -118,7 +118,7 @@ function Finder:create_finder_contents(result,method_type,root_dir)
       end
       local link = vim.uri_to_fname(uri) -- returns lowercase drive letters on Windows
       if libs.is_windows() then
-        link = link:gsub('^%l', link:sub(1, 1):upper())
+        link = link:gsub("^%l", link:sub(1, 1):upper())
       end
       local short_name
 
@@ -129,39 +129,46 @@ function Finder:create_finder_contents(result,method_type,root_dir)
         short_name = link:sub(home_dir:len() + 2)
         -- some definition still has a too long path prefix
         if #short_name > 40 then
-          short_name = libs.split_by_pathsep(short_name,4)
+          short_name = libs.split_by_pathsep(short_name, 4)
         end
       else
-        short_name = libs.split_by_pathsep(link,4)
+        short_name = libs.split_by_pathsep(link, 4)
       end
 
-      local target_line = '['..index..']'..' '..short_name
+      local target_line = "[" .. index .. "]" .. " " .. short_name
       local range = result[index].targetRange or result[index].range
-      if index == 1  then
-        table.insert(self.contents,' ')
+      if index == 1 then
+        table.insert(self.contents, " ")
       end
-      table.insert(self.contents,target_line)
+      table.insert(self.contents, target_line)
       target_lnum = target_lnum + 1
       -- max_preview_lines
       local max_preview_lines = config.max_preview_lines
-      local lines = api.nvim_buf_get_lines(bufnr,range.start.line-0,range["end"].line+1+max_preview_lines,false)
+      local lines = api.nvim_buf_get_lines(
+        bufnr,
+        range.start.line - 0,
+        range["end"].line + 1 + max_preview_lines,
+        false
+      )
 
       self.short_link[target_lnum] = {
-        link=link,
-        preview=lines,
-        row=range.start.line+1,
-        col=range.start.character+1
+        link = link,
+        preview = lines,
+        row = range.start.line + 1,
+        col = range.start.character + 1,
       }
     end
   end
 end
 
 function Finder:render_finder_result()
-  if next(self.contents) == nil then return end
-  table.insert(self.contents,' ')
+  if next(self.contents) == nil then
+    return
+  end
+  table.insert(self.contents, " ")
   -- get dimensions
-  local width = api.nvim_get_option("columns")
-  local height = api.nvim_get_option("lines")
+  local width = api.nvim_get_option "columns"
+  local height = api.nvim_get_option "lines"
 
   -- calculate our floating window size
   local win_height = math.ceil(height * 0.8)
@@ -184,31 +191,31 @@ function Finder:render_finder_result()
 
   local content_opts = {
     contents = self.contents,
-    filetype = 'lspsagafinder',
+    filetype = "lspsagafinder",
     enter = true,
-    highlight = 'LspSagaLspFinderBorder'
+    highlight = "LspSagaLspFinderBorder",
   }
 
-  self.bufnr,self.winid = window.create_win_with_border(content_opts,opts)
-  api.nvim_buf_set_option(self.contents_buf,'buflisted',false)
-  api.nvim_win_set_var(self.conents_win,'lsp_finder_win_opts',opts)
-  api.nvim_win_set_option(self.conents_win,'cursorline',true)
+  self.bufnr, self.winid = window.create_win_with_border(content_opts, opts)
+  api.nvim_buf_set_option(self.contents_buf, "buflisted", false)
+  api.nvim_win_set_var(self.conents_win, "lsp_finder_win_opts", opts)
+  api.nvim_win_set_option(self.conents_win, "cursorline", true)
 
   if not self.cursor_line_bg and not self.cursor_line_fg then
     self:get_cursorline_highlight()
   end
-  api.nvim_command('highlight! link CursorLine LspSagaFinderSelection')
-  api.nvim_command('autocmd CursorMoved <buffer> lua require("lspsaga.provider").set_cursor()')
-  api.nvim_command('autocmd CursorMoved <buffer> lua require("lspsaga.provider").auto_open_preview()')
-  api.nvim_command("autocmd QuitPre <buffer> lua require('lspsaga.provider').close_lsp_finder_window()")
+  api.nvim_command "highlight! link CursorLine LspSagaFinderSelection"
+  api.nvim_command 'autocmd CursorMoved <buffer> lua require("lspsaga.provider").set_cursor()'
+  api.nvim_command 'autocmd CursorMoved <buffer> lua require("lspsaga.provider").auto_open_preview()'
+  api.nvim_command "autocmd QuitPre <buffer> lua require('lspsaga.provider').close_lsp_finder_window()"
 
-  for i=1,self.definition_uri,1 do
-    api.nvim_buf_add_highlight(self.contents_buf,-1,"TargetFileName",1+i,0,-1)
+  for i = 1, self.definition_uri, 1 do
+    api.nvim_buf_add_highlight(self.contents_buf, -1, "TargetFileName", 1 + i, 0, -1)
   end
 
-  for i=1,self.reference_uri,1 do
+  for i = 1, self.reference_uri, 1 do
     local def_count = self.definition_uri ~= 0 and self.definition_uri or -1
-    api.nvim_buf_add_highlight(self.contents_buf,-1,"TargetFileName",i+def_count+4,0,-1)
+    api.nvim_buf_add_highlight(self.contents_buf, -1, "TargetFileName", i + def_count + 4, 0, -1)
   end
   -- load float window map
   self:apply_float_map()
@@ -217,51 +224,61 @@ end
 
 function Finder:apply_float_map()
   local action = config.finder_action_keys
-  local nvim_create_keymap = require('lspsaga.libs').nvim_create_keymap
+  local nvim_create_keymap = require("lspsaga.libs").nvim_create_keymap
   local lhs = {
     noremap = true,
-    silent = true
+    silent = true,
   }
   local keymaps = {
-    {self.bufnr,'n',action.vsplit,":lua require'lspsaga.provider'.open_link(2)<CR>"},
-    {self.bufnr,'n',action.split,":lua require'lspsaga.provider'.open_link(3)<CR>"},
-    {self.bufnr,'n',action.scroll_down,":lua require'lspsaga.provider'.scroll_in_preview(1)<CR>"},
-    {self.bufnr,'n',action.scroll_up,":lua require'lspsaga.provider'.scroll_in_preview(-1)<CR>"}
+    { self.bufnr, "n", action.vsplit, ":lua require'lspsaga.provider'.open_link(2)<CR>" },
+    { self.bufnr, "n", action.split, ":lua require'lspsaga.provider'.open_link(3)<CR>" },
+    { self.bufnr, "n", action.scroll_down, ":lua require'lspsaga.provider'.scroll_in_preview(1)<CR>" },
+    { self.bufnr, "n", action.scroll_up, ":lua require'lspsaga.provider'.scroll_in_preview(-1)<CR>" },
   }
 
-  if type(action.open) == 'table' then
-    for _,key in ipairs(action.open) do
-      table.insert(keymaps,{self.bufnr,'n',key,":lua require'lspsaga.provider'.open_link(1)<CR>"})
+  if type(action.open) == "table" then
+    for _, key in ipairs(action.open) do
+      table.insert(keymaps, { self.bufnr, "n", key, ":lua require'lspsaga.provider'.open_link(1)<CR>" })
     end
-  elseif type(action.open) == 'string' then
-    table.insert(keymaps,{self.bufnr,'n',action.open,":lua require'lspsaga.provider'.open_link(1)<CR>"})
+  elseif type(action.open) == "string" then
+    table.insert(keymaps, { self.bufnr, "n", action.open, ":lua require'lspsaga.provider'.open_link(1)<CR>" })
   end
 
-  if type(action.quit) == 'table' then
-    for _,key in ipairs(action.quit) do
-      table.insert(keymaps,{self.bufnr,'n',key,":lua require'lspsaga.provider'.close_lsp_finder_window()<CR>"})
+  if type(action.quit) == "table" then
+    for _, key in ipairs(action.quit) do
+      table.insert(keymaps, { self.bufnr, "n", key, ":lua require'lspsaga.provider'.close_lsp_finder_window()<CR>" })
     end
-  elseif type(action.quit) == 'string' then
-    table.insert(keymaps,{self.bufnr,'n',action.quit,":lua require'lspsaga.provider'.close_lsp_finder_window()<CR>"})
+  elseif type(action.quit) == "string" then
+    table.insert(
+      keymaps,
+      { self.bufnr, "n", action.quit, ":lua require'lspsaga.provider'.close_lsp_finder_window()<CR>" }
+    )
   end
-  nvim_create_keymap(keymaps,lhs)
+  nvim_create_keymap(keymaps, lhs)
 end
 
-function Finder:lsp_finder_highlight ()
-  local def_icon = config.finder_definition_icon or ''
-  local ref_icon = config.finder_reference_icon or ''
+function Finder:lsp_finder_highlight()
+  local def_icon = config.finder_definition_icon or ""
+  local ref_icon = config.finder_reference_icon or ""
   local def_uri_count = self.definition_uri == 0 and -1 or self.definition_uri
   -- add syntax
-  api.nvim_buf_add_highlight(self.contents_buf,-1,"DefinitionIcon",0,1,#def_icon-1)
-  api.nvim_buf_add_highlight(self.contents_buf,-1,"TargetWord",0,#def_icon,self.param_length+#def_icon+3)
-  api.nvim_buf_add_highlight(self.contents_buf,-1,"DefinitionCount",0,0,-1)
-  api.nvim_buf_add_highlight(self.contents_buf,-1,"TargetWord",3+def_uri_count,#ref_icon,self.param_length+#ref_icon+3)
-  api.nvim_buf_add_highlight(self.contents_buf,-1,"ReferencesIcon",3+def_uri_count,1,#ref_icon+4)
-  api.nvim_buf_add_highlight(self.contents_buf,-1,"ReferencesCount",3+def_uri_count,0,-1)
+  api.nvim_buf_add_highlight(self.contents_buf, -1, "DefinitionIcon", 0, 1, #def_icon - 1)
+  api.nvim_buf_add_highlight(self.contents_buf, -1, "TargetWord", 0, #def_icon, self.param_length + #def_icon + 3)
+  api.nvim_buf_add_highlight(self.contents_buf, -1, "DefinitionCount", 0, 0, -1)
+  api.nvim_buf_add_highlight(
+    self.contents_buf,
+    -1,
+    "TargetWord",
+    3 + def_uri_count,
+    #ref_icon,
+    self.param_length + #ref_icon + 3
+  )
+  api.nvim_buf_add_highlight(self.contents_buf, -1, "ReferencesIcon", 3 + def_uri_count, 1, #ref_icon + 4)
+  api.nvim_buf_add_highlight(self.contents_buf, -1, "ReferencesCount", 3 + def_uri_count, 0, -1)
 end
 
 function Finder:set_cursor()
-  local current_line = vim.fn.line('.')
+  local current_line = vim.fn.line "."
   local column = 2
 
   local first_def_uri_lnum = self.definition_uri ~= 0 and 3 or 5
@@ -271,80 +288,104 @@ function Finder:set_cursor()
   local last_ref_uri_lnum = 3 + self.definition_uri + count + self.reference_uri
 
   if current_line == 1 then
-    vim.fn.cursor(first_def_uri_lnum,column)
+    vim.fn.cursor(first_def_uri_lnum, column)
   elseif current_line == last_def_uri_lnum + 1 then
-    vim.fn.cursor(first_ref_uri_lnum,column)
+    vim.fn.cursor(first_ref_uri_lnum, column)
   elseif current_line == last_ref_uri_lnum + 1 then
     vim.fn.cursor(first_def_uri_lnum, column)
   elseif current_line == first_ref_uri_lnum - 1 then
     if self.definition_uri == 0 then
-      vim.fn.cursor(first_def_uri_lnum,column)
+      vim.fn.cursor(first_def_uri_lnum, column)
     else
-      vim.fn.cursor(last_def_uri_lnum,column)
+      vim.fn.cursor(last_def_uri_lnum, column)
     end
   elseif current_line == first_def_uri_lnum - 1 then
-    vim.fn.cursor(last_ref_uri_lnum,column)
+    vim.fn.cursor(last_ref_uri_lnum, column)
   end
 end
 
 function Finder:get_cursorline_highlight()
-  self.cursor_line_bg = vfn.synIDattr(vfn.hlID("cursorline"),"bg")
-  self.cursor_line_fg = vfn.synIDattr(vfn.hlID("cursorline"),"fg")
+  self.cursor_line_bg = vfn.synIDattr(vfn.hlID "cursorline", "bg")
+  self.cursor_line_fg = vfn.synIDattr(vfn.hlID "cursorline", "fg")
 end
 
 function Finder:auto_open_preview()
-  local current_line = vim.fn.line('.')
-  if not self.short_link[current_line] then return end
+  local current_line = vim.fn.line "."
+  if not self.short_link[current_line] then
+    return
+  end
   local content = self.short_link[current_line].preview or {}
 
   if next(content) ~= nil then
-    local has_var,finder_win_opts = pcall(api.nvim_win_get_var,0,'lsp_finder_win_opts')
-    if not has_var then print('get finder window options wrong') return end
-    local width = api.nvim_get_option('columns')
-    local height = vim.fn.winheight(0)
+    local has_var, finder_win_opts = pcall(api.nvim_win_get_var, 0, "lsp_finder_win_opts")
+    if not has_var then
+      print "get finder window options wrong"
+      return
+    end
     local opts = {
-      relative = 'win',
+      relative = "editor",
+      -- We'll make sure the preview window is the correct size
+      no_size_override = true,
     }
 
-    local min_width = 42
-    local pad_right = self.WIN_WIDTH - width - 20 - min_width
-    local max_height = finder_win_opts.height or height
+    local finder_width = vim.fn.winwidth(0)
+    local finder_height = vim.fn.winheight(0)
+    local screen_width = api.nvim_get_option "columns"
 
-    if pad_right >= 0 then
-      opts.col = finder_win_opts.col+width+2
-      opts.row = finder_win_opts.row - 1
-      opts.width = min_width + math.max(0, math.min(math.floor((pad_right-10)/1.5), 60))
+    local content_width = 0
+    for _, line in ipairs(content) do
+      content_width = math.max(vim.fn.strdisplaywidth(line), content_width)
+    end
+
+    local border_width
+    if config.border_style == "double" then
+      border_width = 4
+    else
+      border_width = 2
+    end
+
+    local max_width = screen_width - finder_win_opts.col - finder_width - border_width - 2
+
+    if max_width > 42 then
+      -- Put preview window to the right of the finder window
+      local preview_width = math.min(content_width + border_width, max_width)
+      opts.col = finder_win_opts.col + finder_width + 2
+      opts.row = finder_win_opts.row
+      opts.width = preview_width
       opts.height = self.definition_uri + self.reference_uri + 6
-      if opts.height > max_height then
-        opts.height = max_height
+      if opts.height > finder_height then
+        opts.height = finder_height
       end
-    elseif pad_right < 0 then
-      opts.row = finder_win_opts.row + height + 2
-      opts.col = finder_win_opts.col
-      opts.width = min_width
-      opts.height = 8
-      if self.WIN_HEIGHT - height - opts.row < 4 then
+    else
+      -- Put preview window below the finder window
+      local max_height = self.WIN_HEIGHT - finder_win_opts.row - finder_height - border_width - 2
+      if max_height <= 3 then
         return
-      end
+      end -- Don't show preview window if too short
+
+      opts.row = finder_win_opts.row + finder_height + 2
+      opts.col = finder_win_opts.col
+      opts.width = finder_width
+      opts.height = math.min(8, max_height)
     end
 
     local content_opts = {
       contents = content,
       filetype = self.buf_filetype,
-      highlight = 'LspSagaAutoPreview'
+      highlight = "LspSagaAutoPreview",
     }
 
-    vim.defer_fn(function ()
+    vim.defer_fn(function()
       self:close_auto_preview_win()
-      local bufnr,winid = window.create_win_with_border(content_opts,opts)
-      api.nvim_buf_set_option(bufnr,'buflisted',false)
-      api.nvim_win_set_var(0,'saga_finder_preview',{winid,1,config.max_preview_lines+1})
-    end,10)
+      local bufnr, winid = window.create_win_with_border(content_opts, opts)
+      api.nvim_buf_set_option(bufnr, "buflisted", false)
+      api.nvim_win_set_var(0, "saga_finder_preview", { winid, 1, config.max_preview_lines + 1 })
+    end, 10)
   end
 end
 
 function Finder:close_auto_preview_win()
-  local has_var,pdata = pcall(api.nvim_win_get_var,0,'saga_finder_preview')
+  local has_var, pdata = pcall(api.nvim_win_get_var, 0, "saga_finder_preview")
   if has_var then
     window.nvim_close_valid_window(pdata[1])
   end
@@ -354,29 +395,33 @@ end
 -- action 2 mean vsplit
 -- action 3 mean split
 function Finder:open_link(action_type)
-  local action = {"edit ","vsplit ","split "}
-  local current_line = vim.fn.line('.')
+  local action = { "edit ", "vsplit ", "split " }
+  local current_line = vim.fn.line "."
 
   if self.short_link[current_line] == nil then
-    error('[LspSaga] target file uri not exist')
+    error "[LspSaga] target file uri not exist"
     return
   end
 
   self:close_auto_preview_win()
-  api.nvim_win_close(self.winid,true)
-  api.nvim_command(action[action_type]..self.short_link[current_line].link)
-  vim.fn.cursor(self.short_link[current_line].row,self.short_link[current_line].col)
+  api.nvim_win_close(self.winid, true)
+  api.nvim_command(action[action_type] .. self.short_link[current_line].link)
+  vim.fn.cursor(self.short_link[current_line].row, self.short_link[current_line].col)
   self:clear_tmp_data()
 end
 
 function Finder:scroll_in_preview(direction)
-  local has_var,pdata = pcall(api.nvim_win_get_var,0,'saga_finder_preview')
-  if not has_var then return end
-  if not api.nvim_win_is_valid(pdata[1]) then return end
+  local has_var, pdata = pcall(api.nvim_win_get_var, 0, "saga_finder_preview")
+  if not has_var then
+    return
+  end
+  if not api.nvim_win_is_valid(pdata[1]) then
+    return
+  end
 
-  local current_win_lnum,last_lnum = pdata[3],pdata[4]
-  current_win_lnum = scroll_in_win(pdata[1],direction,current_win_lnum,last_lnum,config.max_preview_lines)
-  api.nvim_win_set_var(0,'saga_finder_preview',{pdata[1],current_win_lnum,last_lnum})
+  local current_win_lnum, last_lnum = pdata[3], pdata[4]
+  current_win_lnum = scroll_in_win(pdata[1], direction, current_win_lnum, last_lnum, config.max_preview_lines)
+  api.nvim_win_set_var(0, "saga_finder_preview", { pdata[1], current_win_lnum, last_lnum })
 end
 
 function Finder:quit_float_window()
@@ -393,20 +438,23 @@ function Finder:clear_tmp_data()
   self.definition_uri = 0
   self.reference_uri = 0
   self.param_length = 0
-  self.buf_filetype = ''
+  self.buf_filetype = ""
   self.WIN_HEIGHT = 0
   self.WIN_WIDTH = 0
-  api.nvim_command('hi! CursorLine  guibg='..self.cursor_line_bg)
-  if self.cursor_line_fg == '' then
-    api.nvim_command('hi! CursorLine  guifg=NONE')
+  api.nvim_command("hi! CursorLine  guibg=" .. self.cursor_line_bg)
+  if self.cursor_line_fg == "" then
+    api.nvim_command "hi! CursorLine  guifg=NONE"
   end
 end
 
 local lspfinder = {}
 
 function lspfinder.lsp_finder()
-  local active,msg = libs.check_lsp_active()
-  if not active then print(msg) return end
+  local active, msg = libs.check_lsp_active()
+  if not active then
+    print(msg)
+    return
+  end
   local async_finder = Finder:lsp_finder_request()
   async_finder:send()
 end
@@ -432,22 +480,26 @@ function lspfinder.scroll_in_preview(direction)
 end
 
 function lspfinder.preview_definition(timeout_ms)
-  local active,msg = libs.check_lsp_active()
-  if not active then print(msg) return end
+  local active, msg = libs.check_lsp_active()
+  if not active then
+    print(msg)
+    return
+  end
   local filetype = vim.api.nvim_buf_get_option(0, "filetype")
 
   local method = "textDocument/definition"
   local params = lsp.util.make_position_params()
-  local result = vim.lsp.buf_request_sync(0,method,params,timeout_ms or 1000)
+  local result = vim.lsp.buf_request_sync(0, method, params, timeout_ms or 1000)
   if result == nil or vim.tbl_isempty(result) then
     print("No location found: " .. method)
     return nil
   end
-  result = {vim.tbl_deep_extend("force", {}, unpack(result))}
 
   if vim.tbl_islist(result) and not vim.tbl_isempty(result[1]) then
     local uri = result[1].result[1].uri or result[1].result[1].targetUri
-    if #uri == 0 then return end
+    if #uri == 0 then
+      return
+    end
     local bufnr = vim.uri_to_bufnr(uri)
     local link = vim.uri_to_fname(uri)
     local short_name
@@ -460,14 +512,14 @@ function lspfinder.preview_definition(timeout_ms)
       short_name = link:sub(home_dir:len() + 2)
       -- some definition still has a too long path prefix
       if #short_name > 40 then
-        short_name = libs.split_by_pathsep(short_name,4)
+        short_name = libs.split_by_pathsep(short_name, 4)
       end
     else
-      short_name = libs.split_by_pathsep(link,4)
+      short_name = libs.split_by_pathsep(link, 4)
     end
 
     if not vim.api.nvim_buf_is_loaded(bufnr) then
-        vim.fn.bufload(bufnr)
+      vim.fn.bufload(bufnr)
     end
     local range = result[1].result[1].targetRange or result[1].result[1].range
     local start_line = 0
@@ -477,16 +529,23 @@ function lspfinder.preview_definition(timeout_ms)
       start_line = range.start.line
     end
 
-    local content =
-        vim.api.nvim_buf_get_lines(bufnr, start_line, range["end"].line + 1 +
-        config.max_preview_lines, false)
-    content = vim.list_extend({config.definition_preview_icon.."Definition Preview: "..short_name,"" },content)
+    local content = vim.api.nvim_buf_get_lines(
+      bufnr,
+      start_line,
+      range["end"].line + 1 + config.max_preview_lines,
+      false
+    )
+    content = vim.list_extend({
+      config.definition_preview_icon .. "Definition Preview: " .. short_name,
+      "",
+    }, content)
 
     local opts = {
       relative = "cursor",
       style = "minimal",
     }
-    local WIN_WIDTH = api.nvim_get_option('columns')
+
+    local WIN_WIDTH = api.nvim_get_option "columns"
     local max_width = math.floor(WIN_WIDTH * 0.5)
     local width, _ = vim.lsp.util._make_floating_popup_size(content, opts)
 
@@ -497,29 +556,32 @@ function lspfinder.preview_definition(timeout_ms)
     local content_opts = {
       contents = content,
       filetype = filetype,
-      highlight = 'LspSagaDefPreviewBorder'
+      highlight = "LspSagaDefPreviewBorder",
     }
 
-    local bf,wi = window.create_win_with_border(content_opts,opts)
-    vim.lsp.util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"},
-                                        wi)
-    vim.api.nvim_buf_add_highlight(bf,-1,"DefinitionPreviewTitle",0,0,-1)
+    local bf, wi = window.create_win_with_border(content_opts, opts)
+    vim.lsp.util.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, wi)
+    vim.api.nvim_buf_add_highlight(bf, -1, "DefinitionPreviewTitle", 0, 0, -1)
 
-    api.nvim_buf_set_var(0,'lspsaga_def_preview',{wi,1,config.max_preview_lines,10})
+    api.nvim_buf_set_var(0, "lspsaga_def_preview", { wi, 1, config.max_preview_lines, 10 })
   end
 end
 
 function lspfinder.has_saga_def_preview()
-  local has_preview,pdata = pcall(api.nvim_buf_get_var,0,'lspsaga_def_preview')
-  if has_preview and api.nvim_win_is_valid(pdata[1]) then return true end
+  local has_preview, pdata = pcall(api.nvim_buf_get_var, 0, "lspsaga_def_preview")
+  if has_preview and api.nvim_win_is_valid(pdata[1]) then
+    return true
+  end
   return false
 end
 
 function lspfinder.scroll_in_def_preview(direction)
-  local has_preview,pdata = pcall(api.nvim_buf_get_var,0,'lspsaga_def_preview')
-  if not has_preview then return end
-  local current_win_lnum = scroll_in_win(pdata[1],direction,pdata[2],config.max_preview_lines,pdata[4])
-  api.nvim_buf_set_var(0,'lspsaga_def_preview',{pdata[1],current_win_lnum,config.max_preview_lines,pdata[4]})
+  local has_preview, pdata = pcall(api.nvim_buf_get_var, 0, "lspsaga_def_preview")
+  if not has_preview then
+    return
+  end
+  local current_win_lnum = scroll_in_win(pdata[1], direction, pdata[2], config.max_preview_lines, pdata[4])
+  api.nvim_buf_set_var(0, "lspsaga_def_preview", { pdata[1], current_win_lnum, config.max_preview_lines, pdata[4] })
 end
 
 return lspfinder

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -1,23 +1,23 @@
-local lsp,util,api = vim.lsp,vim.lsp.util,vim.api
-local window = require('lspsaga.window')
-local config = require('lspsaga').config_values
-local libs = require('lspsaga.libs')
+local lsp, util, api = vim.lsp, vim.lsp.util, vim.api
+local window = require "lspsaga.window"
+local config = require("lspsaga").config_values
+local libs = require "lspsaga.libs"
 
-local unique_name = 'textDocument-rename'
+local unique_name = "textDocument-rename"
 local pos = {}
 
 local get_prompt_prefix = function()
-  return config.rename_prompt_prefix..' '
+  return config.rename_prompt_prefix .. " "
 end
 
 local close_rename_win = function()
-  if vim.fn.mode() == 'i' then
+  if vim.fn.mode() == "i" then
     vim.cmd [[stopinsert]]
   end
-  local has,winid = pcall(api.nvim_win_get_var,0,unique_name)
+  local has, winid = pcall(api.nvim_win_get_var, 0, unique_name)
   if has then
     window.nvim_close_valid_window(winid)
-    api.nvim_win_set_cursor(0,pos)
+    api.nvim_win_set_cursor(0, pos)
     pos = {}
   end
 end
@@ -25,23 +25,32 @@ end
 local apply_action_keys = function()
   local quit_key = config.rename_action_keys.quit
   local exec_key = config.rename_action_keys.exec
-  api.nvim_command('inoremap <buffer><nowait><silent>'..exec_key..' <cmd>lua require("lspsaga.rename").do_rename()<CR>')
+  api.nvim_command(
+    "inoremap <buffer><nowait><silent>" .. exec_key .. ' <cmd>lua require("lspsaga.rename").do_rename()<CR>'
+  )
   if type(quit_key) == "table" then
-    for _,k in ipairs(quit_key) do
-      api.nvim_command('inoremap <buffer><nowait><silent>'..k..' <cmd>lua require("lspsaga.rename").close_rename_win()<CR>')
+    for _, k in ipairs(quit_key) do
+      api.nvim_command(
+        "inoremap <buffer><nowait><silent>" .. k .. ' <cmd>lua require("lspsaga.rename").close_rename_win()<CR>'
+      )
     end
   else
-    api.nvim_command('inoremap <buffer><nowait><silent>'..quit_key..' <cmd>lua require("lspsaga.rename").close_rename_win()<CR>')
+    api.nvim_command(
+      "inoremap <buffer><nowait><silent>" .. quit_key .. ' <cmd>lua require("lspsaga.rename").close_rename_win()<CR>'
+    )
   end
-  api.nvim_command('nnoremap <buffer><silent>q <cmd>lua require("lspsaga.rename").close_rename_win()<CR>')
+  api.nvim_command 'nnoremap <buffer><silent>q <cmd>lua require("lspsaga.rename").close_rename_win()<CR>'
 end
 
 local rename = function()
-  local active,msg = libs.check_lsp_active()
-  if not active then print(msg) return end
+  local active, msg = libs.check_lsp_active()
+  if not active then
+    print(msg)
+    return
+  end
   -- if exist a rename float win close it.
   close_rename_win()
-  pos[1],pos[2] = vim.fn.line('.'),vim.fn.col('.')
+  pos[1], pos[2] = vim.fn.line ".", vim.fn.col "."
 
   local opts = {
     height = 1,
@@ -50,41 +59,41 @@ local rename = function()
 
   local content_opts = {
     contents = {},
-    filetype = '',
+    filetype = "",
     enter = true,
-    highlight = 'LspSagaRenameBorder'
+    highlight = "LspSagaRenameBorder",
   }
 
-  local bufnr,winid = window.create_win_with_border(content_opts,opts)
-  local saga_rename_prompt_prefix = api.nvim_create_namespace('lspsaga_rename_prompt_prefix')
-  api.nvim_win_set_option(winid,'scrolloff',0)
-  api.nvim_win_set_option(winid,'sidescrolloff',0)
-  api.nvim_buf_set_option(bufnr,'modifiable',true)
+  local bufnr, winid = window.create_win_with_border(content_opts, opts)
+  local saga_rename_prompt_prefix = api.nvim_create_namespace "lspsaga_rename_prompt_prefix"
+  api.nvim_win_set_option(winid, "scrolloff", 0)
+  api.nvim_win_set_option(winid, "sidescrolloff", 0)
+  api.nvim_buf_set_option(bufnr, "modifiable", true)
   local prompt_prefix = get_prompt_prefix()
-  api.nvim_buf_set_option(bufnr,'buftype','prompt')
+  api.nvim_buf_set_option(bufnr, "buftype", "prompt")
   vim.fn.prompt_setprompt(bufnr, prompt_prefix)
-  api.nvim_buf_add_highlight(bufnr, saga_rename_prompt_prefix, 'LspSagaRenamePromptPrefix', 0, 0, #prompt_prefix)
+  api.nvim_buf_add_highlight(bufnr, saga_rename_prompt_prefix, "LspSagaRenamePromptPrefix", 0, 0, #prompt_prefix)
   vim.cmd [[startinsert!]]
-  api.nvim_win_set_var(0,unique_name,winid)
-  api.nvim_command("autocmd QuitPre <buffer> ++nested ++once :silent lua require('lspsaga.rename').close_rename_win()")
+  api.nvim_win_set_var(0, unique_name, winid)
+  api.nvim_command "autocmd QuitPre <buffer> ++nested ++once :silent lua require('lspsaga.rename').close_rename_win()"
   apply_action_keys()
 end
 
 local do_rename = function()
   local prompt_prefix = get_prompt_prefix()
-  local new_name = vim.trim(vim.fn.getline('.'):sub(#prompt_prefix+1,-1))
+  local new_name = vim.trim(vim.fn.getline("."):sub(#prompt_prefix + 1, -1))
   close_rename_win()
   local params = util.make_position_params()
-  local current_name = vim.fn.expand('<cword>')
+  local current_name = vim.fn.expand "<cword>"
   if not (new_name and #new_name > 0) or new_name == current_name then
     return
   end
   params.newName = new_name
-  lsp.buf_request(0,'textDocument/rename', params)
+  lsp.buf_request(0, "textDocument/rename", params)
 end
 
 return {
   rename = rename,
   do_rename = do_rename,
-  close_rename_win = close_rename_win
+  close_rename_win = close_rename_win,
 }

--- a/lua/lspsaga/signaturehelp.lua
+++ b/lua/lspsaga/signaturehelp.lua
@@ -1,10 +1,10 @@
-local util,api = vim.lsp.util,vim.api
+local util, api = vim.lsp.util, vim.api
 local npcall = vim.F.npcall
-local window = require('lspsaga.window')
-local config = require('lspsaga').config_values
-local wrap = require('lspsaga.wrap')
-local libs = require('lspsaga.libs')
-local action = require('lspsaga.action')
+local window = require "lspsaga.window"
+local config = require("lspsaga").config_values
+local wrap = require "lspsaga.wrap"
+local libs = require "lspsaga.libs"
+local action = require "lspsaga.action"
 
 local function find_window_by_var(name, value)
   for _, win in ipairs(api.nvim_list_wins()) do
@@ -17,10 +17,13 @@ end
 -- disable signature help when only efm-langserver
 -- issue #103
 local function check_server_support_signaturehelp()
-  local active,msg = libs.check_lsp_active()
-  if not active then print(msg) return end
+  local active, msg = libs.check_lsp_active()
+  if not active then
+    print(msg)
+    return
+  end
   local clients = vim.lsp.buf_get_clients()
-  for _,client in pairs(clients) do
+  for _, client in pairs(clients) do
     if client.resolved_capabilities.signature_help == true then
       return true
     end
@@ -31,18 +34,18 @@ end
 local function focusable_float(unique_name, fn)
   -- Go back to previous window if we are in a focusable one
   if npcall(api.nvim_win_get_var, 0, unique_name) then
-    return api.nvim_command("wincmd p")
+    return api.nvim_command "wincmd p"
   end
   local bufnr = api.nvim_get_current_buf()
   do
     local win = find_window_by_var(unique_name, bufnr)
     if win and api.nvim_win_is_valid(win) and not vim.fn.pumvisible() then
       api.nvim_set_current_win(win)
-      api.nvim_command("stopinsert")
+      api.nvim_command "stopinsert"
       return
     end
   end
-  local pbufnr, pwinnr,_,_= fn()
+  local pbufnr, pwinnr, _, _ = fn()
   if pbufnr then
     api.nvim_win_set_var(pwinnr, unique_name, bufnr)
     return pbufnr, pwinnr
@@ -50,9 +53,11 @@ local function focusable_float(unique_name, fn)
 end
 
 local function apply_syntax_to_region(ft, start, finish)
-  if ft == '' then return end
-  local name = ft..'signature'
-  local lang = "@"..ft:upper()
+  if ft == "" then
+    return
+  end
+  local name = ft .. "signature"
+  local lang = "@" .. ft:upper()
   -- TODO(ashkan): better validation before this.
   if not pcall(vim.cmd, string.format("syntax include %s syntax/%s.vim", lang, ft)) then
     return
@@ -62,12 +67,9 @@ end
 
 local function focusable_preview(unique_name, fn)
   return focusable_float(unique_name, function()
-    local contents,_ = fn()
-    local filetype = api.nvim_buf_get_option(0,'filetype')
-    vim.validate {
-      contents = { contents, 't' };
-      filetype = { filetype, 's', true };
-    }
+    local contents, _ = fn()
+    local filetype = api.nvim_buf_get_option(0, "filetype")
+    vim.validate { contents = { contents, "t" }, filetype = { filetype, "s", true } }
     local opts = {}
     -- Clean up input: trim empty lines from the end, pad
     contents = util._trim(contents, opts)
@@ -82,10 +84,10 @@ local function focusable_preview(unique_name, fn)
 
     local max_width = window.get_max_float_width()
 
-    if width ~= max_width  then
+    if width ~= max_width then
       width = max_width
     end
-    contents = wrap.wrap_contents(contents,width)
+    contents = wrap.wrap_contents(contents, width)
 
     local WIN_HEIGHT = vim.fn.winheight(0)
     local max_height = math.ceil((WIN_HEIGHT - 4) * 0.5)
@@ -93,67 +95,71 @@ local function focusable_preview(unique_name, fn)
       opts.height = max_height
     end
 
-    local wrap_index = #wrap.wrap_text(first_line,width)
+    local wrap_index = #wrap.wrap_text(first_line, width)
     if #contents ~= 1 then
       local truncate_line = wrap.add_truncate_line(contents)
-      table.insert(contents,wrap_index + 1,truncate_line)
+      table.insert(contents, wrap_index + 1, truncate_line)
     end
 
     local content_opts = {
       contents = contents,
-      filetype = 'sagasignature',
-      highlight = 'LspSagaSignatureHelpBorder'
+      filetype = "sagasignature",
+      highlight = "LspSagaSignatureHelpBorder",
     }
 
-    local bufnr,winid = window.create_win_with_border(content_opts,opts)
-    api.nvim_buf_add_highlight(bufnr,-1,'LspSagaShTruncateLine',wrap_index,0,-1)
-    api.nvim_buf_set_var(0,'saga_signature_help_win',{winid,1,#contents,max_height})
+    local bufnr, winid = window.create_win_with_border(content_opts, opts)
+    api.nvim_buf_add_highlight(bufnr, -1, "LspSagaShTruncateLine", wrap_index, 0, -1)
+    api.nvim_buf_set_var(0, "saga_signature_help_win", { winid, 1, #contents, max_height })
     local cwin = api.nvim_get_current_win()
     api.nvim_set_current_win(winid)
-    apply_syntax_to_region(filetype,1,wrap_index)
+    apply_syntax_to_region(filetype, 1, wrap_index)
     api.nvim_set_current_win(cwin)
-    util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"}, winid)
-    return bufnr,winid
+    util.close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }, winid)
+    return bufnr, winid
   end)
 end
 
-local has_saga_signature = function ()
-  local saga_signature_win = npcall(api.nvim_buf_get_var,0,'saga_signature_help_win')
+local has_saga_signature = function()
+  local saga_signature_win = npcall(api.nvim_buf_get_var, 0, "saga_signature_help_win")
   if saga_signature_win and api.nvim_win_is_valid(saga_signature_win[1]) then
     return true
   end
   return false
 end
 
-local scroll_in_signature = function (direction)
-  if not has_saga_signature() then return end
-  local sdata = api.nvim_buf_get_var(0,'saga_signature_help_win')
-  local swin,current_win_lnum,last_lnum,height = sdata[1],sdata[2],sdata[3],sdata[4]
-  current_win_lnum = action.scroll_in_win(swin,direction,current_win_lnum,last_lnum,height)
-  api.nvim_buf_set_var(0,'saga_signature_help_win',{swin,current_win_lnum,last_lnum,height})
+local scroll_in_signature = function(direction)
+  if not has_saga_signature() then
+    return
+  end
+  local sdata = api.nvim_buf_get_var(0, "saga_signature_help_win")
+  local swin, current_win_lnum, last_lnum, height = sdata[1], sdata[2], sdata[3], sdata[4]
+  current_win_lnum = action.scroll_in_win(swin, direction, current_win_lnum, last_lnum, height)
+  api.nvim_buf_set_var(0, "saga_signature_help_win", { swin, current_win_lnum, last_lnum, height })
 end
 
-local call_back = function(_, method, result)
+local call_back = function(_, result, ctx, _)
   if not (result and result.signatures and result.signatures[1]) then
---     print('No signature help available')
+    --     print('No signature help available')
     return
   end
   local lines = util.convert_signature_help_to_markdown_lines(result)
   lines = util.trim_empty_lines(lines)
   if vim.tbl_isempty(lines) then
---     print('No signature help available')
+    print "No signature help available"
     return
   end
-  focusable_preview(method, function()
+  focusable_preview(ctx.method, function()
     return lines, util.try_trim_markdown_code_blocks(lines)
   end)
 end
 
 local signature_help = function()
   -- check the server support the signature help
-  if not check_server_support_signaturehelp() then return end
+  if not check_server_support_signaturehelp() then
+    return
+  end
   local params = util.make_position_params()
-  vim.lsp.buf_request(0,'textDocument/signatureHelp', params,call_back)
+  vim.lsp.buf_request(0, "textDocument/signatureHelp", params, call_back)
 end
 
 return {

--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -1,42 +1,43 @@
-local vim,api = vim,vim.api
+local vim, api = vim, vim.api
 local M = {}
-local config = require('lspsaga').config_values
-local wrap = require('lspsaga.wrap')
+local config = require("lspsaga").config_values
+local wrap = require "lspsaga.wrap"
 
-local function get_border_style(style,highlight)
-  highlight = highlight or 'FloatBorder'
+local function get_border_style(style, highlight)
+  highlight = highlight or "FloatBorder"
   local border_style = {
-    ["single"] = "single",["double"] = "double",
+    ["single"] = "single",
+    ["double"] = "double",
     ["round"] = {
-      {"╭", highlight},
-      {"─", highlight},
-      {"╮", highlight},
-      {"│", highlight},
-      {"╯", highlight},
-      {"─", highlight},
-      {"╰", highlight},
-      {"│", highlight}
+      { "╭", highlight },
+      { "─", highlight },
+      { "╮", highlight },
+      { "│", highlight },
+      { "╯", highlight },
+      { "─", highlight },
+      { "╰", highlight },
+      { "│", highlight },
     },
     ["bold"] = {
-      {"┏", highlight},
-      {"─", highlight},
-      {"┓", highlight},
-      {"│", highlight},
-      {"┛", highlight},
-      {"─", highlight},
-      {"┗", highlight},
-      {"│", highlight}
+      { "┏", highlight },
+      { "─", highlight },
+      { "┓", highlight },
+      { "│", highlight },
+      { "┛", highlight },
+      { "─", highlight },
+      { "┗", highlight },
+      { "│", highlight },
     },
     ["plus"] = {
-      {"+", highlight},
-      {"─", highlight},
-      {"+", highlight},
-      {"│", highlight},
-      {"+", highlight},
-      {"─", highlight},
-      {"+", highlight},
-      {"│", highlight}
-    }
+      { "+", highlight },
+      { "─", highlight },
+      { "+", highlight },
+      { "│", highlight },
+      { "+", highlight },
+      { "─", highlight },
+      { "+", highlight },
+      { "│", highlight },
+    },
   }
 
   return border_style[style]
@@ -44,23 +45,23 @@ end
 
 local function make_floating_popup_options(width, height, opts)
   vim.validate {
-    opts = { opts, 't', true };
+    opts = { opts, "t", true },
   }
   opts = opts or {}
   vim.validate {
-    ["opts.offset_x"] = { opts.offset_x, 'n', true };
-    ["opts.offset_y"] = { opts.offset_y, 'n', true };
+    ["opts.offset_x"] = { opts.offset_x, "n", true },
+    ["opts.offset_y"] = { opts.offset_y, "n", true },
   }
   local new_option = {}
 
-  new_option.style = 'minimal'
+  new_option.style = "minimal"
   new_option.width = width
   new_option.height = height
 
   if opts.relative ~= nil then
     new_option.relative = opts.relative
   else
-    new_option.relative = 'cursor'
+    new_option.relative = "cursor"
   end
 
   if opts.anchor ~= nil then
@@ -68,26 +69,25 @@ local function make_floating_popup_options(width, height, opts)
   end
 
   if opts.row == nil and opts.col == nil then
-
     local lines_above = vim.fn.winline() - 1
     local lines_below = vim.fn.winheight(0) - lines_above
-    new_option.anchor = ''
+    new_option.anchor = ""
 
     local pum_pos = vim.fn.pum_getpos()
     local pum_vis = not vim.tbl_isempty(pum_pos) -- pumvisible() can be true and pum_pos() returns {}
-    if pum_vis and vim.fn.line(".") >= pum_pos.row or not pum_vis and lines_above < lines_below then
-      new_option.anchor = 'N'
+    if pum_vis and vim.fn.line "." >= pum_pos.row or not pum_vis and lines_above < lines_below then
+      new_option.anchor = "N"
       new_option.row = 1
     else
-      new_option.anchor = 'S'
+      new_option.anchor = "S"
       new_option.row = -2
     end
 
-    if vim.fn.wincol() + width <= api.nvim_get_option('columns') then
-      new_option.anchor = new_option.anchor..'W'
+    if vim.fn.wincol() + width <= api.nvim_get_option "columns" then
+      new_option.anchor = new_option.anchor .. "W"
       new_option.col = 0
     else
-      new_option.anchor = new_option.anchor..'E'
+      new_option.anchor = new_option.anchor .. "E"
       new_option.col = 1
     end
   else
@@ -98,49 +98,58 @@ local function make_floating_popup_options(width, height, opts)
   return new_option
 end
 
-local function generate_win_opts(contents,opts)
+local function generate_win_opts(contents, opts)
   opts = opts or {}
-  local win_width,win_height = vim.lsp.util._make_floating_popup_size(contents,opts)
+  local win_width, win_height
+  -- _make_floating_popup_size doesn't allow the window size to be larger than
+  -- the current window. For the finder preview window, this means it won't let the
+  -- preview window be wider than the finder window. To work around this, the
+  -- no_size_override option can be set to indicate that the size shouldn't be changed
+  -- from what was given.
+  if opts.no_size_override and opts.width and opts.height then
+    win_width, win_height = opts.width, opts.height
+  else
+    win_width, win_height = vim.lsp.util._make_floating_popup_size(contents, opts)
+  end
   opts = make_floating_popup_options(win_width, win_height, opts)
   return opts
 end
 
 local function get_shadow_config()
-  local opts =  {
-    relative= 'editor',
-    style= 'minimal',
-    width= vim.o.columns,
-    height= vim.o.lines,
-    row= 0,
-    col= 0,
+  local opts = {
+    relative = "editor",
+    style = "minimal",
+    width = vim.o.columns,
+    height = vim.o.lines,
+    row = 0,
+    col = 0,
   }
   return opts
 end
 
 local function open_shadow_win()
   local opts = get_shadow_config()
-  local shadow_winhl = 'Normal:SagaShadow,NormalNC:SagaShadow,EndOfBuffer:SagaShadow'
-  local shadow_bufnr = api.nvim_create_buf(false,true)
-  local shadow_winid = api.nvim_open_win(shadow_bufnr,true,opts)
-  api.nvim_win_set_option(shadow_winid,'winhl',shadow_winhl)
-  api.nvim_win_set_option(shadow_winid,'winblend',70)
-  return shadow_bufnr,shadow_winid
+  local shadow_winhl = "Normal:SagaShadow,NormalNC:SagaShadow,EndOfBuffer:SagaShadow"
+  local shadow_bufnr = api.nvim_create_buf(false, true)
+  local shadow_winid = api.nvim_open_win(shadow_bufnr, true, opts)
+  api.nvim_win_set_option(shadow_winid, "winhl", shadow_winhl)
+  api.nvim_win_set_option(shadow_winid, "winblend", 70)
+  return shadow_bufnr, shadow_winid
 end
 
-
-function M.create_win_with_border(content_opts,opts)
-  vim.validate{
-    content_opts = {content_opts,'t'},
-    contents = {content_opts.content,'t',true},
-    opts = {opts,'t',true}
+function M.create_win_with_border(content_opts, opts)
+  vim.validate {
+    content_opts = { content_opts, "t" },
+    contents = { content_opts.content, "t", true },
+    opts = { opts, "t", true },
   }
 
-  local contents,filetype = content_opts.contents,content_opts.filetype
+  local contents, filetype = content_opts.contents, content_opts.filetype
   local enter = content_opts.enter or false
-  local highlight = content_opts.highlight or 'LspFloatWinBorder'
+  local highlight = content_opts.highlight or "LspFloatWinBorder"
   opts = opts or {}
-  opts = generate_win_opts(contents,opts)
-  opts.border = get_border_style(config.border_style,highlight)
+  opts = generate_win_opts(contents, opts)
+  opts.border = get_border_style(config.border_style, highlight)
 
   -- create contents buffer
   local bufnr = api.nvim_create_buf(false, true)
@@ -149,29 +158,29 @@ function M.create_win_with_border(content_opts,opts)
   local content = vim.lsp.util._trim(contents)
 
   if filetype then
-    api.nvim_buf_set_option(bufnr, 'filetype', filetype)
+    api.nvim_buf_set_option(bufnr, "filetype", filetype)
   end
 
-  api.nvim_buf_set_lines(bufnr,0,-1,true,content)
-  api.nvim_buf_set_option(bufnr, 'modifiable', false)
-  api.nvim_buf_set_option(bufnr, 'bufhidden', 'wipe')
-  api.nvim_buf_set_option(bufnr, 'buftype', 'nofile')
+  api.nvim_buf_set_lines(bufnr, 0, -1, true, content)
+  api.nvim_buf_set_option(bufnr, "modifiable", false)
+  api.nvim_buf_set_option(bufnr, "bufhidden", "wipe")
+  api.nvim_buf_set_option(bufnr, "buftype", "nofile")
 
   local winid = api.nvim_open_win(bufnr, enter, opts)
-  if filetype == 'markdown' then
-    api.nvim_win_set_option(winid, 'conceallevel', 2)
+  if filetype == "markdown" then
+    api.nvim_win_set_option(winid, "conceallevel", 2)
   end
 
-  api.nvim_win_set_option(winid,"winhl","Normal:LspFloatWinNormal,FloatBorder:"..highlight)
-  api.nvim_win_set_option(winid,'winblend',0)
-  api.nvim_win_set_option(winid, 'foldlevel', 100)
-  return bufnr,winid
+  api.nvim_win_set_option(winid, "winhl", "Normal:LspFloatWinNormal,FloatBorder:" .. highlight)
+  api.nvim_win_set_option(winid, "winblend", 0)
+  api.nvim_win_set_option(winid, "foldlevel", 100)
+  return bufnr, winid
 end
 
-function M.open_shadow_float_win(content_opts,opts)
-  local shadow_bufnr,shadow_winid = open_shadow_win()
-  local contents_bufnr,contents_winid = M.create_win_with_border(content_opts,opts)
-  return contents_bufnr,contents_winid,shadow_bufnr,shadow_winid
+function M.open_shadow_float_win(content_opts, opts)
+  local shadow_bufnr, shadow_winid = open_shadow_win()
+  local contents_bufnr, contents_winid = M.create_win_with_border(content_opts, opts)
+  return contents_bufnr, contents_winid, shadow_bufnr, shadow_winid
 end
 
 function M.get_max_float_width()
@@ -187,14 +196,14 @@ end
 local function get_valid_screen_width()
   local screen_width = vim.o.columns
 
-  if vim.fn.winnr('$') > 1 then
+  if vim.fn.winnr "$" > 1 then
     local special_win = {
-      ['NvimTree'] = true,
-      ['NerdTree'] = true,
+      ["NvimTree"] = true,
+      ["NerdTree"] = true,
     }
     local first_win_id = api.nvim_list_wins()[1]
     local bufnr = vim.fn.winbufnr(first_win_id)
-    local buf_ft = api.nvim_buf_get_option(bufnr,'filetype')
+    local buf_ft = api.nvim_buf_get_option(bufnr, "filetype")
     if special_win[buf_ft] then
       screen_width = screen_width - vim.fn.winwidth(first_win_id)
     end
@@ -204,8 +213,8 @@ local function get_valid_screen_width()
 end
 
 local function get_max_content_length(contents)
-  vim.validate{
-    contents = { contents,'t' }
+  vim.validate {
+    contents = { contents, "t" },
   }
   if next(contents) == nil then
     return 0
@@ -214,8 +223,8 @@ local function get_max_content_length(contents)
     return #contents[1]
   end
   local tmp = {}
-  for _,text in ipairs(contents) do
-    tmp[#tmp+1] = #text
+  for _, text in ipairs(contents) do
+    tmp[#tmp + 1] = #text
   end
   table.sort(tmp)
   return tmp[#tmp]
@@ -223,8 +232,8 @@ end
 
 function M.fancy_floating_markdown(contents, opts)
   vim.validate {
-    contents = { contents, 't' };
-    opts = { opts, 't', true };
+    contents = { contents, "t" },
+    opts = { opts, "t", true },
   }
   opts = opts or {}
 
@@ -235,7 +244,7 @@ function M.fancy_floating_markdown(contents, opts)
     while i <= #contents do
       local line = contents[i]
       -- TODO(ashkan): use a more strict regex for filetype?
-      local ft = line:match("^```([a-zA-Z0-9_]*)$")
+      local ft = line:match "^```([a-zA-Z0-9_]*)$"
       -- local ft = line:match("^```(.*)$")
       -- TODO(ashkan): validate the filetype here.
       if ft then
@@ -251,9 +260,9 @@ function M.fancy_floating_markdown(contents, opts)
           i = i + 1
         end
         table.insert(highlights, {
-          ft = ft;
-          start = start + 1;
-          finish = #stripped + 1 - 1;
+          ft = ft,
+          start = start + 1,
+          finish = #stripped + 1 - 1,
         })
       else
         table.insert(stripped, line)
@@ -289,52 +298,54 @@ function M.fancy_floating_markdown(contents, opts)
     opts.height = max_height
   end
 
-  stripped = wrap.wrap_contents(stripped,width)
+  stripped = wrap.wrap_contents(stripped, width)
 
-  local wraped_index = #wrap.wrap_text(firstline,width)
+  local wraped_index = #wrap.wrap_text(firstline, width)
 
   -- if only has one line do not insert truncate line
   if #stripped ~= 1 then
     local truncate_line = wrap.add_truncate_line(stripped)
-    if stripped[1]:find('{%s$') then
-      for idx,text in ipairs(stripped) do
-        if text == '} ' or text == '}' then
+    if stripped[1]:find "{%s$" then
+      for idx, text in ipairs(stripped) do
+        if text == "} " or text == "}" then
           wraped_index = idx
           break
         end
       end
     end
     if wraped_index ~= #stripped then
-      table.insert(stripped,wraped_index+1,truncate_line)
+      table.insert(stripped, wraped_index + 1, truncate_line)
     end
   end
 
   local content_opts = {
     contents = stripped,
-    filetype = 'sagahover',
-    highlight = 'LspSagaHoverBorder'
+    filetype = "sagahover",
+    highlight = "LspSagaHoverBorder",
   }
 
   -- Make the floating window.
-  local bufnr,winid = M.create_win_with_border(content_opts,opts)
+  local bufnr, winid = M.create_win_with_border(content_opts, opts)
   local height = opts.height or #stripped
-  api.nvim_win_set_var(0,'lspsaga_hoverwin_data',{winid,height,height,#stripped})
+  api.nvim_win_set_var(0, "lspsaga_hoverwin_data", { winid, height, height, #stripped })
 
-  api.nvim_buf_add_highlight(bufnr,-1,'LspSagaDocTruncateLine',wraped_index,0,-1)
+  api.nvim_buf_add_highlight(bufnr, -1, "LspSagaDocTruncateLine", wraped_index, 0, -1)
 
   -- Switch to the floating window to apply the syntax highlighting.
   -- This is because the syntax command doesn't accept a target.
   local cwin = vim.api.nvim_get_current_win()
   vim.api.nvim_set_current_win(winid)
 
-  vim.cmd("ownsyntax markdown")
+  vim.cmd "ownsyntax markdown"
   local idx = 1
   --@private
   local function apply_syntax_to_region(ft, start, finish)
-    if ft == '' then return end
-    local name = ft..idx
+    if ft == "" then
+      return
+    end
+    local name = ft .. idx
     idx = idx + 1
-    local lang = "@"..ft:upper()
+    local lang = "@" .. ft:upper()
     -- TODO(ashkan): better validation before this.
     if not pcall(vim.cmd, string.format("syntax include %s syntax/%s.vim", lang, ft)) then
       return
@@ -353,41 +364,43 @@ function M.fancy_floating_markdown(contents, opts)
   end
 
   vim.api.nvim_set_current_win(cwin)
-  return bufnr,winid
+  return bufnr, winid
 end
 
 function M.nvim_close_valid_window(winid)
   local close_win = function(win_id)
-    if win_id == 0 then return end
+    if win_id == 0 then
+      return
+    end
     if vim.api.nvim_win_is_valid(win_id) then
-      api.nvim_win_close(win_id,true)
+      api.nvim_win_close(win_id, true)
     end
   end
 
   local _switch = {
     ["table"] = function()
-      for _,id in ipairs(winid) do
+      for _, id in ipairs(winid) do
         close_win(id)
       end
     end,
     ["number"] = function()
       close_win(winid)
-    end
+    end,
   }
 
   local _switch_metatable = {
-    __index = function(_,t)
-      error(string.format('Wrong type %s of winid',t))
-    end
+    __index = function(_, t)
+      error(string.format("Wrong type %s of winid", t))
+    end,
   }
 
-  setmetatable(_switch,_switch_metatable)
+  setmetatable(_switch, _switch_metatable)
 
   _switch[type(winid)]()
 end
 
 function M.nvim_win_try_close()
-  local has_var,line_diag_winids = pcall(api.nvim_win_get_var,0,"show_line_diag_winids")
+  local has_var, line_diag_winids = pcall(api.nvim_win_get_var, 0, "show_line_diag_winids")
   if has_var and line_diag_winids ~= nil then
     M.nvim_close_valid_window(line_diag_winids)
   end

--- a/lua/lspsaga/wrap.lua
+++ b/lua/lspsaga/wrap.lua
@@ -1,49 +1,49 @@
-local config = require('lspsaga').config_values
+local config = require("lspsaga").config_values
 local wrap = {}
 
 -- If the content too long.
 -- auto wrap according width
 -- fill the space with wrap text
-function wrap.wrap_text(text,width,opts)
+function wrap.wrap_text(text, width, opts)
   opts = opts or {}
   local ret = {}
-  local space = ' '
+  local space = " "
   local pad_left = opts.pad_left or 0
   -- if text width < width just return it
   if #text <= width then
-    table.insert(ret,text)
+    table.insert(ret, text)
     return ret
   end
 
-  local _truncate = function (t,w)
+  local _truncate = function(t, w)
     local tmp = t
     local tbl = {}
     while true do
       if #tmp > w then
-        table.insert(tbl,tmp:sub(1,w))
-        if tmp:find('^%c//') then
-          tmp = '\t// ' .. tmp:sub(w+1)
+        table.insert(tbl, tmp:sub(1, w))
+        if tmp:find "^%c//" then
+          tmp = "\t// " .. tmp:sub(w + 1)
         else
-          tmp = tmp:sub(w+1)
+          tmp = tmp:sub(w + 1)
         end
       else
-        table.insert(tbl,tmp)
+        table.insert(tbl, tmp)
         break
       end
     end
     return tbl
   end
-  ret = _truncate(text,width)
+  ret = _truncate(text, width)
 
-  local pad = ''
+  local pad = ""
   if pad_left ~= 0 then
-    for _=1,pad_left,1 do
+    for _ = 1, pad_left, 1 do
       pad = pad .. space
     end
   end
 
   if opts.fill then
-    for i=2,#ret,1 do
+    for i = 2, #ret, 1 do
       ret[i] = pad .. ret[i]
     end
   end
@@ -51,21 +51,21 @@ function wrap.wrap_text(text,width,opts)
   return ret
 end
 
-function wrap.wrap_contents(contents,width,opts)
+function wrap.wrap_contents(contents, width, opts)
   opts = opts or {}
   if type(contents) ~= "table" then
-    error("Wrong params type of function wrap_contents")
+    error "Wrong params type of function wrap_contents"
     return
   end
   local stripped = {}
 
   for _, text in ipairs(contents) do
     if #text < width then
-      table.insert(stripped,text)
+      table.insert(stripped, text)
     else
-      local tmp = wrap.wrap_text(text,width,opts)
-      for _,j in ipairs(tmp) do
-        table.insert(stripped,j)
+      local tmp = wrap.wrap_text(text, width, opts)
+      for _, j in ipairs(tmp) do
+        table.insert(stripped, j)
       end
     end
   end
@@ -76,15 +76,15 @@ end
 function wrap.add_truncate_line(contents)
   local line_widths = {}
   local width = 0
-  local char = config.border_style == 4 and '-' or '─'
+  local char = config.border_style == 4 and "-" or "─"
   local truncate_line = char
 
-  for i,line in ipairs(contents) do
+  for i, line in ipairs(contents) do
     line_widths[i] = vim.fn.strdisplaywidth(line)
     width = math.max(line_widths[i], width)
   end
 
-  for _=1,width,1 do
+  for _ = 1, width, 1 do
     truncate_line = truncate_line .. char
   end
 

--- a/plugin/lspsaga.vim
+++ b/plugin/lspsaga.vim
@@ -1,18 +1,18 @@
 if exists('g:loaded_lspsaga') | finish | endif
 
-let s:save_cpo = &cpo
-set cpo&vim
+let s:save_cpo = &cpoptions
+set cpoptions&vim
 
 if !has('nvim')
     echohl Error
-    echom "Sorry this plugin only works with versions of neovim that support lua"
+    echom 'Sorry this plugin only works with versions of neovim that support lua'
     echohl clear
     finish
 endif
 
 let g:loaded_lspsaga = 1
 
-let s:bg_color = synIDattr(hlID("Normal"), "bg")
+let s:bg_color = synIDattr(hlID('Normal'), 'bg')
 
 highlight default LspSagaFinderSelection guifg=#89d957 guibg=NONE gui=bold
 
@@ -73,5 +73,5 @@ endfunction
 " LspSaga Commands with complete
 command! -nargs=+ -complete=custom,s:lspsaga_complete Lspsaga    lua require('lspsaga.command').load_command(<f-args>)
 
-let &cpo = s:save_cpo
+let &cpoptions = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Fixes the 'horizontal rule' in the diagnostic popup when not showing a header.
Gives the option to not prefix diagnostic messages with a number.

Personally I use: show_header=false, border_style=none , prefix_diagnostic=false

The borders, headers, prefixes etc are just visual clutter.