### PR TITLE
remove the use of close_preview_autocmd

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -127,7 +127,9 @@ local function show_diagnostics(opts, get_diagnostics)
     end
   end
   api.nvim_buf_add_highlight(bufnr,-1,'LspSagaDiagnosticTruncateLine',1,0,-1)
-  util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"}, winid)
+  api.nvim_command(
+    string.format('autocmd CursorMoved,CursorMovedI,BufHidden,BufLeave <buffer> ++once lua pcall(vim.api.nvim_win_close, %d, true)', winid)
+  )
   api.nvim_win_set_var(0,"show_line_diag_winids",winid)
   return winid
 end

--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -25,7 +25,9 @@ hover.handler = function(_, method, result)
     window.nvim_win_try_close()
     local bufnr,winid = window.fancy_floating_markdown(markdown_lines)
 
-    lsp.util.close_preview_autocmd({"CursorMoved", "BufHidden","BufLeave", "InsertCharPre"}, winid)
+    api.nvim_command(
+      string.format('autocmd CursorMoved,BufHidden,BufLeave,InsertCharPre <buffer> ++once lua pcall(vim.api.nvim_win_close, %d, true)', winid)
+    )
     return bufnr,winid
   end)
 end

--- a/lua/lspsaga/implement.lua
+++ b/lua/lspsaga/implement.lua
@@ -57,7 +57,9 @@ function implement.lspsaga_implementation(timeout_ms)
     }
 
     local bf,wi = window.create_win_with_border(content_opts,opts)
-    vim.lsp.util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"},
+    api.nvim_command(
+      string.format('autocmd CursorMoved,CursorMovedI,BufHidden,BufLeave <buffer> ++once lua pcall(vim.api.nvim_win_close, %d, true)', winid)
+    )
                                         wi)
     vim.api.nvim_buf_add_highlight(bf,-1,"DefinitionPreviewTitle",0,0,-1)
 

--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -501,7 +501,9 @@ function lspfinder.preview_definition(timeout_ms)
     }
 
     local bf,wi = window.create_win_with_border(content_opts,opts)
-    vim.lsp.util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"},
+    api.nvim_command(
+      string.format('autocmd CursorMoved,CursorMovedI,BufHidden,BufLeave <buffer> ++once lua pcall(vim.api.nvim_win_close, %d, true)', winid)
+    )
                                         wi)
     vim.api.nvim_buf_add_highlight(bf,-1,"DefinitionPreviewTitle",0,0,-1)
 

--- a/lua/lspsaga/signaturehelp.lua
+++ b/lua/lspsaga/signaturehelp.lua
@@ -112,7 +112,9 @@ local function focusable_preview(unique_name, fn)
     api.nvim_set_current_win(winid)
     apply_syntax_to_region(filetype,1,wrap_index)
     api.nvim_set_current_win(cwin)
-    util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"}, winid)
+    api.nvim_command(
+      string.format('autocmd CursorMoved,CursorMovedI,BufHidden,BufLeave <buffer> ++once lua pcall(vim.api.nvim_win_close, %d, true)', winid)
+    )
     return bufnr,winid
   end)
 end


### PR DESCRIPTION
This PR removes the use of close_preview_autocmd from the project. `close_preview_autocmd` function seems to be removed from nightly neovim due to this I get the error below when I try to open a hover or diagnostic window.

```
Error executing vim.schedule lua callback: /home/ss/.vim/plugged/lspsaga.nvim/lua/lspsaga/hover.lua:35: attempt to call field 'close_preview_autocmd' (a nil value)                                                  
stack traceback:
        /home/ss/.vim/plugged/lspsaga.nvim/lua/lspsaga/hover.lua:35: in function 'fn'
        /home/ss/.vim/plugged/lspsaga.nvim/lua/lspsaga/hover.lua:12: in function 'focusable_float'
        /home/ss/.vim/plugged/lspsaga.nvim/lua/lspsaga/hover.lua:20: in function 'handler'
        /usr/share/nvim/runtime/lua/vim/lsp.lua:964: in function ''
        vim.lua: in function <vim.lua:0>
```
Similar to this https://github.com/neovim/nvim-lspconfig/pull/1575