### PR TITLE
Fixed deprecated function

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -32,7 +32,7 @@ function M.lsp_jump_diagnostic_next(opts)
   return _iter_diagnostic_move_pos(
     "DiagnosticNext",
     opts,
-    vim.lsp.diagnostic.get_next_pos(opts)
+    vim.diagnostic.get(opts)
   )
 end
 


### PR DESCRIPTION
This change should make `:Lspsaga diagnostic()` work properly