### PR TITLE
fix: using lib close_preview_autocmd everywhere

### DIFF
--- a/lua/lspsaga/implement.lua
+++ b/lua/lspsaga/implement.lua
@@ -57,7 +57,7 @@ function implement.lspsaga_implementation(timeout_ms)
     }
 
     local bf,wi = window.create_win_with_border(content_opts,opts)
-    vim.lsp.util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"},
+    libs.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"},
                                         wi)
     vim.api.nvim_buf_add_highlight(bf,-1,"DefinitionPreviewTitle",0,0,-1)
 

--- a/lua/lspsaga/provider.lua
+++ b/lua/lspsaga/provider.lua
@@ -506,7 +506,7 @@ function lspfinder.preview_definition(timeout_ms)
     }
 
     local bf,wi = window.create_win_with_border(content_opts,opts)
-    vim.lsp.util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"},
+    libs.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"},
                                         wi)
     vim.api.nvim_buf_add_highlight(bf,-1,"DefinitionPreviewTitle",0,0,-1)
 


### PR DESCRIPTION
vim.lsp.util is throwing an error for me as it does not have close_preview_autocmd. Perhaps this was deprecated?

This PR just uses the utility you created everywhere, so it doesn't break in some places based on the vim api.

An example of the bug I was getting before this PR:

```
E5108: Error executing lua ...ethan/.vim/plugged/lspsaga.nvim/lua/lspsaga/provider.lua:509: attempt to call field 'close_preview_autocmd' (a nil value)                                                                                                                                                                                                                                     
stack traceback:                                                                                                                                                                                                                                                                                                                                                                            
        ...ethan/.vim/plugged/lspsaga.nvim/lua/lspsaga/provider.lua:509: in function 'preview_definition'                                                                                                                                                                                                                                                                                   
        [string ":lua"]:1: in main chunk 
```