### PR TITLE
Improve rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ finder_action_keys = {
 code_action_keys = {
   quit = 'q',exec = '<CR>'
 },
+-- default is true when you in rename window it will select the current word
+rename_into_visual = true,
 rename_action_keys = {
   quit = '<C-c>',exec = '<CR>'  -- quit can be a table
 },
 definition_preview_icon = '  '
 "single" "double" "rounded" "bold" "plus"
 border_style = "single"
-rename_prompt_prefix = '➤',
 if you don't use nvim-lspconfig you must pass your server name and
 the related filetypes into this table
 like server_filetype_map = {metals = {'sbt', 'scala'}}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ rename_action_keys = {
   quit = '<C-c>',exec = '<CR>'  -- quit can be a table
 },
 definition_preview_icon = '  '
-"single" "double" "round" "plus"
+"single" "double" "rounded" "bold" "plus"
 border_style = "single"
 rename_prompt_prefix = '➤',
 if you don't use nvim-lspconfig you must pass your server name and

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -25,10 +25,10 @@ saga.config_values = {
   code_action_keys = {
     quit = 'q',exec = '<CR>'
   },
+  rename_into_visual = true,
   rename_action_quit = '<C-c>',
   definition_preview_icon = '  ',
   border_style = "single",
-  rename_prompt_prefix = '➤',
   server_filetype_map = {}
 }
 

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -25,7 +25,6 @@ saga.config_values = {
   code_action_keys = {
     quit = 'q',exec = '<CR>'
   },
-  rename_into_visual = true,
   rename_action_quit = '<C-c>',
   definition_preview_icon = '  ',
   border_style = "single",

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -43,6 +43,8 @@ local apply_action_keys = function(bufnr)
   local opts = {nowait = true,silent = true,noremap = true}
 
   api.nvim_buf_set_keymap(bufnr,'i',exec_key,rhs_of_exec,opts)
+  api.nvim_buf_set_keymap(bufnr,'n',exec_key,rhs_of_exec,opts)
+
   api.nvim_buf_set_keymap(bufnr,'i',quit_key,rhs_of_quit,opts)
   api.nvim_buf_set_keymap(bufnr,'n',quit_key,rhs_of_quit,opts)
   api.nvim_buf_set_keymap(bufnr,'v',quit_key,rhs_of_quit,opts)

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -126,7 +126,12 @@ local lsp_rename = function()
   local bufnr,winid = window.create_win_with_border(content_opts,opts)
   set_local_options()
   api.nvim_buf_set_lines(bufnr,-2,-1,false,{current_word})
-  vim.cmd [[normal viw]]
+
+  if config.rename_into_visual then
+    vim.cmd [[normal! viw]]
+  else
+    vim.cmd [[startinsert!]]
+  end
 
   api.nvim_win_set_var(0,unique_name,winid)
   api.nvim_create_autocmd('QuitPre',{

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -101,6 +101,14 @@ local find_reference = function()
   end
 end
 
+local feedkeys = function(keys,mode)
+  api.nvim_feedkeys(
+    api.nvim_replace_termcodes(keys, true, true, true),
+    mode,
+    true
+  )
+end
+
 local lsp_rename = function()
   local active,msg = libs.check_lsp_active()
   if not active then vim.notify(msg) return end
@@ -127,11 +135,8 @@ local lsp_rename = function()
   set_local_options()
   api.nvim_buf_set_lines(bufnr,-2,-1,false,{current_word})
 
-  if config.rename_into_visual then
-    vim.cmd [[normal! viw]]
-  else
-    vim.cmd [[startinsert!]]
-  end
+  vim.cmd [[normal! viw]]
+  feedkeys('<C-g>','v')
 
   api.nvim_win_set_var(0,unique_name,winid)
   api.nvim_create_autocmd('QuitPre',{

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -4,12 +4,8 @@ local config = require('lspsaga').config_values
 local libs = require('lspsaga.libs')
 
 local unique_name = 'textDocument-rename'
-local saga_rename_prompt_prefix = api.nvim_create_namespace('lspsaga_rename_prompt_prefix')
 local pos = {}
 
-local get_prompt_prefix = function()
-  return config.rename_prompt_prefix..' '
-end
 
 -- store the CursorWord highlight
 local cursorword_hl = {}
@@ -30,7 +26,7 @@ local close_rename_win = function()
   if has then
     window.nvim_close_valid_window(winid)
   end
-  api.nvim_win_set_cursor(0,{pos[1],pos[2] + 1})
+  api.nvim_win_set_cursor(0,{pos[1],pos[2]})
 
   if next(cursorword_hl) ~= nil then
     api.nvim_set_hl(0,'CursorWord',cursorword_hl)
@@ -41,18 +37,22 @@ end
 
 local apply_action_keys = function(bufnr)
   local quit_key = config.rename_action_quit
+  local exec_key = '<CR>'
   local rhs_of_quit = [[<cmd>lua require('lspsaga.rename').close_rename_win()<CR>]]
+  local rhs_of_exec = [[<cmd>lua require("lspsaga.rename").do_rename()<CR>]]
   local opts = {nowait = true,silent = true,noremap = true}
 
+  api.nvim_buf_set_keymap(bufnr,'i',exec_key,rhs_of_exec,opts)
   api.nvim_buf_set_keymap(bufnr,'i',quit_key,rhs_of_quit,opts)
   api.nvim_buf_set_keymap(bufnr,'n',quit_key,rhs_of_quit,opts)
+  api.nvim_buf_set_keymap(bufnr,'v',quit_key,rhs_of_quit,opts)
 end
 
 local set_local_options = function()
   local opt_locals = {
     scrolloff = 0,
     sidescrolloff = 0,
-    modifiable = true
+    modifiable = true,
   }
 
   for opt,val in pairs(opt_locals) do
@@ -101,18 +101,10 @@ local find_reference = function()
   end
 end
 
-local feedkeys = function(keys,mode)
-  api.nvim_feedkeys(
-    api.nvim_replace_termcodes(keys, true, true, true),
-    mode,
-    true
-  )
-end
-
 local lsp_rename = function()
   local active,msg = libs.check_lsp_active()
   if not active then vim.notify(msg) return end
-  local current_buf = api.nvim_get_current_buf()
+--   local current_buf = api.nvim_get_current_buf()
   local current_win = api.nvim_get_current_win()
   local current_word = vim.fn.expand('<cword>')
   pos = api.nvim_win_get_cursor(current_win)
@@ -133,29 +125,8 @@ local lsp_rename = function()
 
   local bufnr,winid = window.create_win_with_border(content_opts,opts)
   set_local_options()
-
-  local prompt_prefix = get_prompt_prefix()
-  api.nvim_buf_set_option(bufnr,'buftype','prompt')
-  vim.fn.prompt_setprompt(bufnr, prompt_prefix)
-  api.nvim_buf_add_highlight(bufnr, saga_rename_prompt_prefix, 'LspSagaRenamePromptPrefix', 0, 0, #prompt_prefix)
-
-  local options = {
-    bufnr = current_buf
-  }
-  vim.fn.prompt_setcallback(bufnr,function(new_name)
-    close_rename_win()
-    api.nvim_win_set_cursor(current_win,pos)
-    vim.lsp.buf.rename(new_name,options)
-    api.nvim_win_set_cursor(current_win,{pos[1],pos[2]+1})
-    pos = {}
-  end)
-
-  vim.cmd [[startinsert!]]
-  -- TODO: find a way to change the mode to visual mode then select the
-  -- current word will be better but prompt buffer looks like some wired.
-  -- can not use feedkesy("<ESC>") and other command to do it. it will cause
-  -- the current word disappear.
-  feedkeys(current_word,'i')
+  api.nvim_buf_set_lines(bufnr,-2,-1,false,{current_word})
+  vim.cmd [[normal viw]]
 
   api.nvim_win_set_var(0,unique_name,winid)
   api.nvim_create_autocmd('QuitPre',{
@@ -169,7 +140,22 @@ local lsp_rename = function()
   apply_action_keys(bufnr)
 end
 
+local function do_rename()
+  local new_name = vim.trim(api.nvim_get_current_line())
+  close_rename_win()
+  local current_name = vim.fn.expand('<cword>')
+  if not (new_name and #new_name > 0) or new_name == current_name then
+    return
+  end
+  local current_win = api.nvim_get_current_win()
+  api.nvim_win_set_cursor(current_win,pos)
+  vim.lsp.buf.rename(new_name)
+  api.nvim_win_set_cursor(current_win,{pos[1],pos[2]+1})
+  pos = {}
+end
+
 return {
   lsp_rename = lsp_rename,
   close_rename_win = close_rename_win,
+  do_rename = do_rename
 }

--- a/lua/lspsaga/symbol.lua
+++ b/lua/lspsaga/symbol.lua
@@ -1,0 +1,7 @@
+local symbol = {}
+
+function symbol.show_symbol_definition()
+
+end
+
+return symbol

--- a/lua/lspsaga/symbol.lua
+++ b/lua/lspsaga/symbol.lua
@@ -1,7 +1,0 @@
-local symbol = {}
-
-function symbol.show_symbol_definition()
-
-end
-
-return symbol

--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -7,16 +7,7 @@ local function get_border_style(style,highlight)
   highlight = highlight or 'FloatBorder'
   local border_style = {
     ["single"] = "single",["double"] = "double",
-    ["round"] = {
-      {"╭", highlight},
-      {"─", highlight},
-      {"╮", highlight},
-      {"│", highlight},
-      {"╯", highlight},
-      {"─", highlight},
-      {"╰", highlight},
-      {"│", highlight}
-    },
+    ["rounded"] = 'rounded',
     ["bold"] = {
       {"┏", highlight},
       {"─", highlight},
@@ -230,6 +221,7 @@ local function get_max_content_length(contents)
   return tmp[#tmp]
 end
 
+-- TODO: better doc render
 function M.fancy_floating_markdown(contents, opts)
   vim.validate {
     contents = { contents, 't' };
@@ -320,7 +312,7 @@ function M.fancy_floating_markdown(contents, opts)
 
   local content_opts = {
     contents = stripped,
-    filetype = 'sagahover',
+    filetype = 'markdown',
     highlight = 'LspSagaHoverBorder'
   }
 

--- a/plugin/lspsaga.lua
+++ b/plugin/lspsaga.lua
@@ -23,7 +23,6 @@ local highlights = {
   LspSagaHoverTrunCateLine = { link = 'LspSagaHoverBorder'},
   -- rename
   LspSagaRenameBorder = { fg = '#3bb6c4'},
-  LspSagaRenamePromptPrefix = {fg= '#98be65'},
   LspSagaRenameMatch = { link = 'Search'},
   -- diagnostic
   LspSagaDiagnosticError = { link = 'DiagnosticError'},


### PR DESCRIPTION
use normal buffer instead of prompt-buffer. in normal buffer we can into visual mode ,I think this is useful . and there has a new option `rename_into_visual` default is true. if set false. won't into visual mode in rename window. remove `rename_prmpt_prefix` option.