### PR TITLE
fix content with newlines

### DIFF
--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -152,8 +152,15 @@ function M.create_win_with_border(content_opts,opts)
     api.nvim_buf_set_option(bufnr, 'filetype', filetype)
   end
 
-  api.nvim_buf_set_lines(bufnr,0,-1,true,content)
-  api.nvim_buf_set_option(bufnr, 'modifiable', false)
+	content = vim.tbl_flatten(vim.tbl_map(function (line)
+		if string.find(line,'\n') then
+			return vim.split(line, '\n')
+		end
+		return line
+	end, content))
+
+	api.nvim_buf_set_lines(bufnr,0,-1,true,content)
+	api.nvim_buf_set_option(bufnr, 'modifiable', false)
   api.nvim_buf_set_option(bufnr, 'bufhidden', 'wipe')
   api.nvim_buf_set_option(bufnr, 'buftype', 'nofile')
 


### PR DESCRIPTION
When I use work for tsx/jsx, if I meet a error and I press <leader>j(which is map to command `:Lspsaga diagnostic_jump_prev`). It will throw a error message(connot contains newlines).

With debug print,I found that `typescript-language-server` will response to a message which the line maybe contains `\n` special character and `nvim_buf_set_lines` api not allow a string contains `\n`character.

before this commit:
![without](https://user-images.githubusercontent.com/57695072/175329728-a31ff3a4-c331-467f-a035-aabf61a850f8.gif)
after this commit:
![with](https://user-images.githubusercontent.com/57695072/175330649-3060b906-7dd7-4ddc-a115-ede411e66bff.gif)

