### PR TITLE
Add augroup for autocmd created by lspsaga

### DIFF
--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -4,6 +4,7 @@ local config = require('lspsaga').config_values
 local wrap = require('lspsaga.wrap')
 local libs = require('lspsaga.libs')
 local method = 'textDocument/codeAction'
+local saga_augroup = require('lspsaga').saga_augroup
 
 
 local Action = {}
@@ -49,6 +50,7 @@ function Action:action_callback()
     -- initial position in code action window
     api.nvim_win_set_cursor(self.action_winid,{3,1})
     api.nvim_create_autocmd('CursorMoved',{
+      group = saga_augroup,
       buffer = self.action_bufnr,
       callback = function()
         require('lspsaga.codeaction'):set_cursor()
@@ -56,6 +58,7 @@ function Action:action_callback()
     })
 
     api.nvim_create_autocmd('QuitPre',{
+      group = saga_augroup,
       buffer = self.action_bufnr,
       callback = function()
         require('lspsaga.codeaction'):quit_action_window()

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -4,6 +4,7 @@ local config = require('lspsaga').config_values
 local lsp,fn,api = vim.lsp,vim.fn,vim.api
 local scroll_in_win = require('lspsaga.action').scroll_in_win
 local def = {}
+local saga_augroup = require('lspsaga').saga_augroup
 
 function def.preview_definition(timeout_ms)
   local active,msg = libs.check_lsp_active()
@@ -78,6 +79,7 @@ function def.preview_definition(timeout_ms)
 
     local current_buf = api.nvim_get_current_buf()
     api.nvim_create_autocmd({"CursorMoved", "CursorMovedI","BufHidden", "BufLeave"},{
+      group = saga_augroup,
       buffer = current_buf,
       once = true,
       callback = function()

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -5,6 +5,7 @@ local config = require('lspsaga').config_values
 local libs = require('lspsaga.libs')
 local home_dir = libs.get_home_dir()
 local scroll_in_win = require('lspsaga.action').scroll_in_win
+local saga_augroup = require('lspsaga').saga_augroup
 
 local methods = {"textDocument/definition","textDocument/references"}
 
@@ -225,18 +226,21 @@ function Finder:render_finder_result()
   api.nvim_command('highlight! link CursorLine LspSagaFinderSelection')
 
   api.nvim_create_autocmd('CursorMoved',{
+    group = saga_augroup,
     buffer = self.bufnr,
     callback = function()
       require('lspsaga.finder'):set_cursor()
     end
   })
   api.nvim_create_autocmd('CursorMoved',{
+    group = saga_augroup,
     buffer = self.bufnr,
     callback = function()
       require('lspsaga.finder'):auto_open_preview()
     end
   })
   api.nvim_create_autocmd('QuitPre',{
+    group = saga_augroup,
     buffer = self.bufnr,
     callback = function()
       require('lspsaga.finder'):quit_float_window()

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -1,5 +1,7 @@
 local api = vim.api
+
 local saga = {}
+saga.saga_augroup = api.nvim_create_augroup('Lspsaga', {})
 
 saga.config_values = {
   debug = false,
@@ -54,6 +56,7 @@ function saga.init_lsp_saga(opts)
   extend_config(opts)
   if saga.config_values.code_action_lightbulb.enable then
     api.nvim_create_autocmd({'CursorHold','CursorHoldI'},{
+      group = saga.saga_augroup,
       pattern = '*',
       callback = require('lspsaga.lightbulb').action_lightbulb
     })

--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -1,6 +1,7 @@
 local api = vim.api
 local libs = {}
 local server_filetype_map = require('lspsaga').config_values.server_filetype_map
+local saga_augroup = require('lspsaga').saga_augroup
 
 function libs.is_windows()
   return vim.loop.os_uname().sysname:find("Windows", 1, true) and true
@@ -130,6 +131,7 @@ end
 
 function libs.close_preview_autocmd(bufnr,winid,events)
   api.nvim_create_autocmd(events,{
+    group = saga_augroup,
     buffer = bufnr,
     once = true,
     callback = function()

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -2,6 +2,7 @@ local api,util,lsp = vim.api,vim.lsp.util,vim.lsp
 local window = require('lspsaga.window')
 local config = require('lspsaga').config_values
 local libs = require('lspsaga.libs')
+local saga_augroup = require('lspsaga').saga_augroup
 
 local unique_name = 'textDocument-rename'
 local pos = {}
@@ -143,6 +144,7 @@ local lsp_rename = function()
 
   api.nvim_win_set_var(0,unique_name,winid)
   api.nvim_create_autocmd('QuitPre',{
+    group = saga_augroup,
     buffer = bufnr,
     once = true,
     nested = true,


### PR DESCRIPTION
autocmd created by `nvim_create_autocmd` using a lua function doesn't have a good string representation:
if you want to know what autocmds you have in an event, like `:autocmd CursorHoldI`,
you will only see a `lua function`, this makes debugging becomes much more difficult if you have some unexpected behavior which might comes from autocmd, if autocmd comes from an anonymous group, this thing becomes worse: you completely have no idea where this autocmd comes from and don't know how to debug.
I add augroup for all the autocmd created by `lspsaga` to mitigate this kind of issues as it is at least better than an anonymous group.


<img width="717" alt="Screen Shot 2022-06-26 at 03 42 48" src="https://user-images.githubusercontent.com/45728125/175804624-fd81dcdc-9570-4261-be85-907290c85f0f.png">

