### PR TITLE
add `alter` param for smart_scroll_with_saga

### DIFF
--- a/lua/lspsaga/action.lua
+++ b/lua/lspsaga/action.lua
@@ -2,7 +2,7 @@ local api = vim.api
 local action = {}
 
 -- direction must 1 or -1
-function action.smart_scroll_with_saga(direction)
+function action.smart_scroll_with_saga(direction, alter)
   local hover = require('lspsaga.hover')
   local def = require('lspsaga.definition')
   local signature = require('lspsaga.signaturehelp')
@@ -17,8 +17,7 @@ function action.smart_scroll_with_saga(direction)
   elseif implement.has_implement_win() then
     implement.scroll_in_implement(direction)
   else
-    local map = direction == 1 and "<C-f>" or "<C-b>"
-    local key = api.nvim_replace_termcodes(map,true,false,true)
+    local key = api.nvim_replace_termcodes(alter,true,false,true)
     api.nvim_feedkeys(key,'n',true)
   end
 end

--- a/lua/lspsaga/action.lua
+++ b/lua/lspsaga/action.lua
@@ -2,7 +2,7 @@ local api = vim.api
 local action = {}
 
 -- direction must 1 or -1
-function action.smart_scroll_with_saga(direction, alter)
+function action.smart_scroll_with_saga(direction, ...)
   local hover = require('lspsaga.hover')
   local def = require('lspsaga.definition')
   local signature = require('lspsaga.signaturehelp')
@@ -16,8 +16,9 @@ function action.smart_scroll_with_saga(direction, alter)
     signature.scroll_in_signature(direction)
   elseif implement.has_implement_win() then
     implement.scroll_in_implement(direction)
-  else
-    local key = api.nvim_replace_termcodes(alter,true,false,true)
+  elseif next({...}) ~= nil then
+    local args = {...}
+    local key = api.nvim_replace_termcodes(args[1],true,false,true)
     api.nvim_feedkeys(key,'n',true)
   end
 end


### PR DESCRIPTION
In my [LEOVIM](https://github.com/leoatchina/leovim/blob/master/runtime/lua/lsp-search.lua#L124), I would like to using `<C-j>/<C-k>` as `%/g%` ， so I add a `alter` param instead of  `<C-f>/<C-b>` in the origin function body