### PR TITLE
Fix custom cli commands in open_float_terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,14 +335,16 @@ src="https://user-images.githubusercontent.com/41671631/176679585-9485676b-ddea-
 local term = require("lspsaga.floaterm")
 
 -- float terminal also you can pass the cli command in open_float_terminal function
-vim.keymap.set("n", "<A-d>", term.open_float_terminal, { silent = true,noremap = true })
+vim.keymap.set("n", "<A-d>", function()
+    term.open_float_terminal("custom_cli_command")
+end, { silent = true,noremap = true })
 vim.keymap.set("t", "<A-d>", function()
     vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<C-\\><C-n>", true, false, true))
     term.close_float_terminal()
 end, { silent = true })
 
 -- or use command
-vim.keymap.set("n", "<A-d>", "<cmd>Lspsaga open_floaterm<CR>", { silent = true,noremap = true })
+vim.keymap.set("n", "<A-d>", "<cmd>Lspsaga open_floaterm custom_cli_command<CR>", { silent = true,noremap = true })
 vim.keymap.set("t", "<A-d>", "<C-\\><C-n><cmd>Lspsaga close_floaterm<CR>", { silent = true,noremap =true })
 ```
 

--- a/lua/lspsaga/floaterm.lua
+++ b/lua/lspsaga/floaterm.lua
@@ -1,7 +1,8 @@
 local api = vim.api
 local window = require 'lspsaga.window'
+local M = {}
 
-local function open_float_terminal(command,border_style)
+function M.open_float_terminal(command,border_style)
   local cmd = command or ''
   border_style = border_style or 0
 
@@ -34,19 +35,16 @@ local function open_float_terminal(command,border_style)
   }
 
   local cb,cw,_,ow = window.open_shadow_float_win(content_opts,opts)
-  api.nvim_command('terminal '..cmd)
+  vim.fn.termopen(cmd, {on_exit = function(...) M.close_float_terminal() end})
   api.nvim_command('setlocal nobuflisted')
   api.nvim_command('startinsert!')
   api.nvim_buf_set_var(cb,'float_terminal_win',{cw,ow})
 end
 
-local function close_float_terminal()
+function M.close_float_terminal()
   local has_var,float_terminal_win = pcall(api.nvim_buf_get_var,0,'float_terminal_win')
   if not has_var then return end
   window.nvim_close_valid_window(float_terminal_win)
 end
 
-return {
-  open_float_terminal = open_float_terminal,
-  close_float_terminal = close_float_terminal
-}
+return  M

--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -157,15 +157,17 @@ function M.create_win_with_border(content_opts,opts)
     api.nvim_buf_set_option(bufnr, 'filetype', filetype)
   end
 
-	content = vim.tbl_flatten(vim.tbl_map(function (line)
-		if string.find(line,'\n') then
-			return vim.split(line, '\n')
-		end
-		return line
-	end, content))
+  content = vim.tbl_flatten(vim.tbl_map(function (line)
+    if string.find(line,'\n') then
+      return vim.split(line, '\n')
+    end
+    return line
+  end, content))
 
-	api.nvim_buf_set_lines(bufnr,0,-1,true,content)
-	api.nvim_buf_set_option(bufnr, 'modifiable', false)
+  if not vim.tbl_isempty(content) then
+    api.nvim_buf_set_lines(bufnr, 0, -1, true, content)
+  end
+  api.nvim_buf_set_option(bufnr, 'modifiable', false)
   api.nvim_buf_set_option(bufnr, 'bufhidden', 'wipe')
   api.nvim_buf_set_option(bufnr, 'buftype', 'nofile')
 

--- a/plugin/lspsaga.lua
+++ b/plugin/lspsaga.lua
@@ -53,7 +53,7 @@ for group,conf in pairs(highlights) do
 end
 
 api.nvim_create_user_command('Lspsaga',function(args)
-  require('lspsaga.command').load_command(args.args)
+  require('lspsaga.command').load_command(unpack(args.fargs))
 end,{
   nargs = "+",
   complete = require('lspsaga.command').command_list,


### PR DESCRIPTION
* Allow custom cli commands to be passed through `:Lspsaga open_floaterm`
* Close the floating window and the shadow window correctly when the custom cli command ends.
* Add docs for custom cli commands.