### PR TITLE
make jk useabe and ban more motion

### DIFF
--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -145,7 +145,7 @@ function libs.close_preview_autocmd(bufnr,winid,events)
 end
 
 function libs.disable_move_keys(bufnr)
-  local keys = { 'h','j','k','l','w','b','<Bs>'}
+  local keys = { 'h','ge','e','0','$','l','w','b','<Bs>'}
   local opts = { nowait = true,noremap = true,silent = true}
   for _,key in pairs(keys) do
     api.nvim_buf_set_keymap(bufnr,'n',key,'',opts)


### PR DESCRIPTION
Well, I think it should be added back, because:
1. as a vimmer, when I see a block cusor, that mean I am in normal mode, so I will try to move up and down with `jk` first time.
2. in some way, \<C-n> and \<C-p> trully a  idiom usage to move up and down in vim but only in insert mode, because single input will input character, since now we are in normal mode, there would be no need to input composite keys, that why `vim model` is a awesome concept because it reduce our input complexity.

also, I banned more motion according to your origin idea