### PR TITLE
fix: allow to overwrite highlight groups 

### DIFF
--- a/plugin/lspsaga.lua
+++ b/plugin/lspsaga.lua
@@ -49,7 +49,7 @@ local highlights = {
 }
 
 for group,conf in pairs(highlights) do
-  api.nvim_set_hl(0,group,conf)
+  api.nvim_set_hl(0, group, vim.tbl_extend('keep', conf, { default = true }))
 end
 
 api.nvim_create_user_command('Lspsaga',function(args)


### PR DESCRIPTION
Provide the `default` option when highlight is set.
Currently `lspsaga.nvim` overwrites all highlight groups after the initialization, this change allows colorscheme providers to change the colors

```
The [default] argument is used for setting the default highlighting for a
group.	If highlighting has already been specified for the group the command
will be ignored.  Also when there is an existing link.
```