### PR TITLE
Fixes check for code action support

### DIFF
--- a/lua/lspsaga/lightbulb.lua
+++ b/lua/lspsaga/lightbulb.lua
@@ -14,7 +14,7 @@ end
 local function check_server_support_codeaction()
   local clients = vim.lsp.buf_get_clients()
     for _,client in pairs(clients) do
-      if client.server_capabilities.codeActionProvider then
+      if client.supports_method("textDocument/codeAction") then
         return true
       end
     end


### PR DESCRIPTION
I was getting an annoying error when no servers supported codeactions on the current buffer(#268, #259)

"Error detected while processing CursorHold Autocommands for "*":                     
method textDocument/codeAction is not supported by any of the servers registered for the current buffer"

This seems to have fixed it.