### PR TITLE
feat(diagnostic): goto_* functions accept options

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ vim.keymap.set("n", "[E", function()
 	require("lspsaga.diagnostic").goto_prev({ severity = vim.diagnostic.severity.ERROR })
 end, { silent = true, noremap = true })
 vim.keymap.set("n", "]E", function()
-	require("lspsaga.diagnostic").goto_prev({ severity = vim.diagnostic.severity.ERROR })
+	require("lspsaga.diagnostic").goto_next({ severity = vim.diagnostic.severity.ERROR })
 end, { silent = true, noremap = true })
 -- or use command
 vim.keymap.set("n", "[e", "<cmd>Lspsaga diagnostic_jump_next<CR>", { silent = true, noremap = true })

--- a/README.md
+++ b/README.md
@@ -348,6 +348,13 @@ vim.keymap.set("n", "<leader>cd", "<cmd>Lspsaga show_line_diagnostics<CR>", { si
 -- jump diagnostic
 vim.keymap.set("n", "[e", require("lspsaga.diagnostic").goto_prev, { silent = true, noremap =true })
 vim.keymap.set("n", "]e", require("lspsaga.diagnostic").goto_next, { silent = true, noremap =true })
+-- or jump to error
+vim.keymap.set("n", "[E", function()
+	require("lspsaga.diagnostic").goto_prev({ severity = vim.diagnostic.severity.ERROR })
+end, { silent = true, noremap = true })
+vim.keymap.set("n", "]E", function()
+	require("lspsaga.diagnostic").goto_prev({ severity = vim.diagnostic.severity.ERROR })
+end, { silent = true, noremap = true })
 -- or use command
 vim.keymap.set("n", "[e", "<cmd>Lspsaga diagnostic_jump_next<CR>", { silent = true, noremap = true })
 vim.keymap.set("n", "]e", "<cmd>Lspsaga diagnostic_jump_prev<CR>", { silent = true, noremap = true })

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -102,14 +102,14 @@ local function move_cursor(entry)
   render_diagnostic_window(entry)
 end
 
-function diag.goto_next()
-  local next = vim.diagnostic.get_next()
+function diag.goto_next(opts)
+  local next = vim.diagnostic.get_next(opts)
   if next == nil then return end
   move_cursor(next)
 end
 
-function diag.goto_prev()
-  local prev = vim.diagnostic.get_prev()
+function diag.goto_prev(opts)
+  local prev = vim.diagnostic.get_prev(opts)
   if not prev then
     return false
   end


### PR DESCRIPTION
Main goal is for users to be able to jump only to errors (ignoring warnings, hints, etc.). We might want to create commands for these as well? Something like `goto_prev_error`?