### PR TITLE
add option to right-align winbar symbols

### DIFF
--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -40,6 +40,7 @@ saga.config_values = {
   symbol_in_winbar = {
     in_custom = false,
     enable = false,
+    right_align = false,
     separator = ' ',
     show_file = true,
     click_support = false

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -118,6 +118,9 @@ local render_symbol_winbar = function()
   end
 
   winbar_val = winbar_val .. str
+  if config.right_align then
+    winbar_val = '%=' .. winbar_val
+  end
   if not config.in_custom then
     api.nvim_win_set_option(current_win,'winbar',winbar_val)
   end


### PR DESCRIPTION
Hi, sorry if this is not the appropriate branch for this pull request, but I thought it would be nice to have the option to right-align the winbar symbols.
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/87934749/177687564-d88e94c4-d700-488e-82c0-da96c223518d.png">

