### PR TITLE
fix(symbolwinbar): Extra space on non-icon buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ to get symbols node and set `User LspsagaUpdateSymbol` event in your autocmds
 -- Example:
 local function get_file_name(include_path)
     local file_name = require("lspsaga.symbolwinbar").get_file_name()
-    if include_path == false then return require("lspsaga.symbolwinbar").get_file_name() end
+    if vim.fn.bufname("%") == "" then return "" end
+    if include_path == false then return file_name end
     -- Else if include path: ./lsp/saga.lua -> lsp > saga.lua
     local path_list = vim.split(vim.fn.expand('%:~:.:h'), vim.loop.os_uname().sysname == "Windows" and '\\' or '/')
     local file_path = "" for _, cur in ipairs(path_list) do file_path = (cur == "." or cur == "~") and "" or file_path .. cur .. ' ' .. '%#LspSagaWinbarSep#>%*' .. ' %*' end
@@ -171,7 +172,9 @@ end
 vim.api.nvim_create_autocmd({ 'CursorHold', 'BufEnter', 'BufWinEnter', 'CursorMoved', 'WinLeave', 'User LspasgaUpdateSymbol' }, {
     pattern = '*',
     callback = function()
-        if vim.fn.winheight(0) > 1 then -- Important if you use telescope
+        if vim.api.nvim_win_get_config(0).zindex then -- Ignore float windows
+            vim.wo.winbar = ""
+        else
             config_winbar()
         end
     end

--- a/README.md
+++ b/README.md
@@ -151,34 +151,33 @@ to get symbols node and set `User LspsagaUpdateSymbol` event in your autocmds
 -- Example:
 local function get_file_name(include_path)
     local file_name = require("lspsaga.symbolwinbar").get_file_name()
-    if vim.fn.bufname("%") == "" then return "" end
+    if vim.fn.bufname "%" == "" then return "" end
     if include_path == false then return file_name end
     -- Else if include path: ./lsp/saga.lua -> lsp > saga.lua
-    local path_list = vim.split(vim.fn.expand('%:~:.:h'), vim.loop.os_uname().sysname == "Windows" and '\\' or '/')
-    local file_path = "" for _, cur in ipairs(path_list) do file_path = (cur == "." or cur == "~") and "" or file_path .. cur .. ' ' .. '%#LspSagaWinbarSep#>%*' .. ' %*' end
+    local path_list = vim.split(vim.fn.expand "%:~:.:h", vim.loop.os_uname().sysname == "Windows" and "\\" or "/")
+    local file_path = "" for _, cur in ipairs(path_list) do file_path = (cur == "." or cur == "~") and "" or file_path .. cur .. " " .. "%#LspSagaWinbarSep#>%*" .. " %*" end
     return file_path .. file_name
 end
 
 local function config_winbar()
-    local ok, lspsaga = pcall(require, 'lspsaga.symbolwinbar')
+    local ok, lspsaga = pcall(require, "lspsaga.symbolwinbar")
     local sym
     if ok then sym = lspsaga.get_symbol_node() end
-    local win_val = ''
+    local win_val = ""
     win_val = get_file_name(false) -- set to true to include path
     if sym ~= nil then win_val = win_val .. sym end
     vim.wo.winbar = win_val
 end
 
-vim.api.nvim_create_autocmd({ 'CursorHold', 'BufEnter', 'BufWinEnter', 'CursorMoved', 'WinLeave', 'User LspasgaUpdateSymbol' }, {
-    pattern = '*',
-    callback = function()
-        if vim.api.nvim_win_get_config(0).zindex then -- Ignore float windows
-            vim.wo.winbar = ""
-        else
-            config_winbar()
-        end
-    end
-})
+vim.api.nvim_create_autocmd( { "CursorHold", "BufEnter", "BufWinEnter", "CursorMoved", "WinLeave", "User LspasgaUpdateSymbol" }, {
+        pattern = "*",
+        callback = function()
+            if vim.api.nvim_win_get_config(0).zindex or vim.bo.buftype == "terminal" then -- Ignore float windows and terminal
+                vim.wo.winbar = ""
+            else config_winbar() end
+        end,
+    }
+)
 ```
 
 ## Support Click in symbols winbar

--- a/README.md
+++ b/README.md
@@ -173,7 +173,11 @@ end
 vim.api.nvim_create_autocmd( { 'CursorHold', 'BufEnter', 'BufWinEnter', 'CursorMoved', 'WinLeave', 'User LspasgaUpdateSymbol' }, {
     pattern = '*',
     callback = function()
-        if vim.api.nvim_win_get_config(0).zindex or vim.bo.buftype == 'terminal' then -- Ignore float windows and terminal
+        local exclude = {
+            ['teminal'] = true,
+            ['prompt'] = true
+        } -- Ignore float windows and exclude filetype
+        if vim.api.nvim_win_get_config(0).zindex or exclude[vim.bo.filetype] then
             vim.wo.winbar = ''
         else
             config_winbar()

--- a/README.md
+++ b/README.md
@@ -150,34 +150,36 @@ to get symbols node and set `User LspsagaUpdateSymbol` event in your autocmds
 ```lua
 -- Example:
 local function get_file_name(include_path)
-    local file_name = require("lspsaga.symbolwinbar").get_file_name()
-    if vim.fn.bufname "%" == "" then return "" end
+    local file_name = require('lspsaga.symbolwinbar').get_file_name()
+    if vim.fn.bufname '%' == '' then return '' end
     if include_path == false then return file_name end
     -- Else if include path: ./lsp/saga.lua -> lsp > saga.lua
-    local path_list = vim.split(vim.fn.expand "%:~:.:h", vim.loop.os_uname().sysname == "Windows" and "\\" or "/")
-    local file_path = "" for _, cur in ipairs(path_list) do file_path = (cur == "." or cur == "~") and "" or file_path .. cur .. " " .. "%#LspSagaWinbarSep#>%*" .. " %*" end
+    local path_list = vim.split(vim.fn.expand '%:~:.:h', vim.loop.os_uname().sysname == 'Windows' and '\\' or '/')
+    local file_path = ''
+    for _, cur in ipairs(path_list) do file_path = (cur == '.' or cur == '~') and '' or file_path .. cur .. ' ' .. '%#LspSagaWinbarSep#>%*' .. ' %*' end
     return file_path .. file_name
 end
 
 local function config_winbar()
-    local ok, lspsaga = pcall(require, "lspsaga.symbolwinbar")
+    local ok, lspsaga = pcall(require, 'lspsaga.symbolwinbar')
     local sym
     if ok then sym = lspsaga.get_symbol_node() end
-    local win_val = ""
+    local win_val = ''
     win_val = get_file_name(false) -- set to true to include path
     if sym ~= nil then win_val = win_val .. sym end
     vim.wo.winbar = win_val
 end
 
-vim.api.nvim_create_autocmd( { "CursorHold", "BufEnter", "BufWinEnter", "CursorMoved", "WinLeave", "User LspasgaUpdateSymbol" }, {
-        pattern = "*",
-        callback = function()
-            if vim.api.nvim_win_get_config(0).zindex or vim.bo.buftype == "terminal" then -- Ignore float windows and terminal
-                vim.wo.winbar = ""
-            else config_winbar() end
-        end,
-    }
-)
+vim.api.nvim_create_autocmd( { 'CursorHold', 'BufEnter', 'BufWinEnter', 'CursorMoved', 'WinLeave', 'User LspasgaUpdateSymbol' }, {
+    pattern = '*',
+    callback = function()
+        if vim.api.nvim_win_get_config(0).zindex or vim.bo.buftype == 'terminal' then -- Ignore float windows and terminal
+            vim.wo.winbar = ''
+        else
+            config_winbar()
+        end
+    end,
+})
 ```
 
 ## Support Click in symbols winbar

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -61,8 +61,12 @@ function def.preview_definition(timeout_ms)
       start_line = range.start.line
     end
 
-    local content =
-      vim.api.nvim_buf_get_lines(bufnr, start_line, range['end'].line + 1 + config.max_preview_lines, false)
+    local content = vim.api.nvim_buf_get_lines(
+      bufnr,
+      start_line,
+      range['end'].line + 1 + config.max_preview_lines,
+      false
+    )
     content = vim.list_extend({ config.definition_preview_icon .. 'Definition Preview: ' .. short_name, '' }, content)
 
     local opts = {

--- a/lua/lspsaga/implement.lua
+++ b/lua/lspsaga/implement.lua
@@ -36,8 +36,12 @@ function implement.lspsaga_implementation(timeout_ms)
       start_line = range.start.line
     end
 
-    local content =
-      vim.api.nvim_buf_get_lines(bufnr, start_line, range['end'].line + 1 + config.max_preview_lines, false)
+    local content = vim.api.nvim_buf_get_lines(
+      bufnr,
+      start_line,
+      range['end'].line + 1 + config.max_preview_lines,
+      false
+    )
     content = vim.list_extend({ config.definition_preview_icon .. 'Lsp Implements', '' }, content)
     local filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
 

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -19,9 +19,9 @@ function symbar:get_file_name()
     f_icon, f_hl = devicons.get_icon_by_filetype(vim.bo.filetype)
   end
   -- if filetype doesn't match devicon will set f_icon to nil so add a patch
-  f_icon = f_icon == nil and '' or f_icon
+	f_icon = f_icon == nil and '' or (f_icon .. ' ')
   f_hl = f_hl == nil and '' or f_hl
-  return '%#' .. f_hl .. '#' .. f_icon .. ' ' .. '%*' .. ns_prefix .. 'File#' .. file_name .. '%*'
+  return '%#' .. f_hl .. '#' .. f_icon .. '%*' .. ns_prefix .. 'File#' .. file_name .. '%*'
 end
 
 --@private

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -19,7 +19,7 @@ function symbar:get_file_name()
     f_icon, f_hl = devicons.get_icon_by_filetype(vim.bo.filetype)
   end
   -- if filetype doesn't match devicon will set f_icon to nil so add a patch
-	f_icon = f_icon == nil and '' or (f_icon .. ' ')
+  f_icon = f_icon == nil and '' or (f_icon .. ' ')
   f_hl = f_hl == nil and '' or f_hl
   return '%#' .. f_hl .. '#' .. f_icon .. '%*' .. ns_prefix .. 'File#' .. file_name .. '%*'
 end

--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -180,7 +180,7 @@ function M.create_win_with_border(content_opts, opts)
   api.nvim_win_set_option(winid, 'winblend', 0)
   api.nvim_win_set_option(winid, 'foldlevel', 100)
   if config.symbol_in_winbar.enable or config.symbol_in_winbar.in_custom then
-    api.nvim_win_set_option(winid,'winbar','')
+    api.nvim_win_set_option(winid, 'winbar', '')
   end
 
   return bufnr, winid


### PR DESCRIPTION
Also, the current winbar behavior is not very good
If `vim.wo.winbar = nil` then it will not remove the extra one line. However `vim.wo.winbar = ""` does... Upstream bug?

https://user-images.githubusercontent.com/56817415/177960834-8f1efa04-cb42-4dc7-b179-5fff209687ec.mp4

in_custom manage to overcome this because I pattern matching every buffer

https://user-images.githubusercontent.com/56817415/177961447-5c8a2106-57df-4712-b3b6-4facdac0c218.mp4


