### PR TITLE
fix left split

### DIFF
--- a/lua/lspsaga/outline.lua
+++ b/lua/lspsaga/outline.lua
@@ -251,7 +251,7 @@ local create_outline_window = function()
     end
   end
 
-  vim.cmd('noautocmd vnew')
+  vim.cmd('noautocmd vsplit')
   vim.cmd('vertical resize ' .. config.show_outline.win_width)
   vim.opt.splitright = user_option
   ot:render_status()


### PR DESCRIPTION
```lua
local saga = require('lspsaga')

saga.init_lsp_saga({
  symbol_in_winbar = {
    enable = true,
  },
  show_outline = {
    win_position = 'left',
  }
})
```
When I use this config, left split will generate new window.
<img width="1470" alt="Screen Shot 2022-07-17 at 10 14 21 PM" src="https://user-images.githubusercontent.com/76530956/179438480-f107987b-3fc3-4f64-8f07-b196decb3802.png">

