### PR TITLE
fix: allow user to pass data into codeaction API

### DIFF
--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -265,24 +265,24 @@ end
 
 local lspaction = {}
 
-lspaction.code_action = function()
-  Action:code_action()
+lspaction.code_action = function(...)
+  Action:code_action(...)
 end
 
-lspaction.do_code_action = function()
-  Action:do_code_action()
+lspaction.do_code_action = function(...)
+  Action:do_code_action(...)
 end
 
-lspaction.quit_action_window = function()
-  Action:quit_action_window()
+lspaction.quit_action_window = function(...)
+  Action:quit_action_window(...)
 end
 
-lspaction.range_code_action = function()
-  Action:range_code_action()
+lspaction.range_code_action = function(...)
+  Action:range_code_action(...)
 end
 
-lspaction.set_cursor = function()
-  Action:set_cursor()
+lspaction.set_cursor = function(...)
+  Action:set_cursor(...)
 end
 
 return lspaction


### PR DESCRIPTION
Previously, all data that was passed as arguments into one of these
functions would be discarded, since these functions are defined to take
no arguments.

This makes it so that these outer API functions pass all arguments
directly to the inner functions. This allows the user to for example
press "2" and actually have "2" transmitted to the inner function,
instead of being lost.

This also may likely prevent a whole host of other potential bugs.