### PR TITLE
Fix hover for objective-c/objective-cpp

### DIFF
--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -263,7 +263,7 @@ function M.fancy_floating_markdown(contents, opts)
     while i <= #contents do
       local line = contents[i]
       -- TODO(ashkan): use a more strict regex for filetype?
-      local ft = line:match('^```([a-zA-Z0-9_]*)$')
+      local ft = line:match('^```([a-zA-Z0-9_-]*)$')
       -- local ft = line:match("^```(.*)$")
       -- TODO(ashkan): validate the filetype here.
       if ft then
@@ -279,7 +279,8 @@ function M.fancy_floating_markdown(contents, opts)
           i = i + 1
         end
         table.insert(highlights, {
-          ft = ft,
+          -- objective-c/objective-cpp -> objc/objcpp 
+          ft = ft:gsub('objective--', 'obj'),
           start = start + 1,
           finish = #stripped + 1 - 1,
         })


### PR DESCRIPTION
Fix hover for `objective-c/objective-cpp`. And sometimes `clang/ccls` also recognizes c/cpp files as objc/objcpp files, this pr also fixes it. 
Before

![1](https://user-images.githubusercontent.com/61791143/185789607-e86253c8-93cd-49f9-83ba-1d16ca655c71.png)

After
![2](https://user-images.githubusercontent.com/61791143/185789615-a7bf1564-727d-4f58-a9b1-502a4bfffcc6.png)

