### PR TITLE
fix(kind): `custom_kind` wouldn't take effect in some occasions.

### DIFF
--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -96,6 +96,7 @@ end
 
 function saga.init_lsp_saga(opts)
   extend_config(opts)
+  require('lspsaga.lspkind').load_custom_kind()
   local conf = saga.config_values
 
   if conf.code_action_lightbulb.enable then

--- a/lua/lspsaga/lspkind.lua
+++ b/lua/lspsaga/lspkind.lua
@@ -56,27 +56,27 @@ local function find_index_by_type(k)
   return nil
 end
 
+if next(custom_kind) ~= nil then
+  for k, conf in pairs(custom_kind) do
+    local index = find_index_by_type(k)
+    if not index then
+      vim.notify('Does not find this type in kind')
+    end
+
+    if type(conf) == 'string' then
+      kind[index][3] = conf
+    end
+
+    if type(conf) == 'table' then
+      kind[index][2] = conf[1]
+      kind[index][3] = conf[2]
+    end
+  end
+end
+
 local function gen_symbol_winbar_hi()
   local prefix = 'LspSagaWinbar'
   local winbar_sep = 'LspSagaWinbarSep'
-
-  if next(custom_kind) ~= nil then
-    for k, conf in pairs(custom_kind) do
-      local index = find_index_by_type(k)
-      if not index then
-        vim.notify('Does not find this type in kind')
-      end
-
-      if type(conf) == 'string' then
-        kind[index][3] = conf
-      end
-
-      if type(conf) == 'table' then
-        kind[index][2] = conf[1]
-        kind[index][3] = conf[2]
-      end
-    end
-  end
 
   for _, v in pairs(kind) do
     api.nvim_set_hl(0, prefix .. v[1], { fg = v[3] })

--- a/lua/lspsaga/lspkind.lua
+++ b/lua/lspsaga/lspkind.lua
@@ -56,20 +56,22 @@ local function find_index_by_type(k)
   return nil
 end
 
-if next(custom_kind) ~= nil then
-  for k, conf in pairs(custom_kind) do
-    local index = find_index_by_type(k)
-    if not index then
-      vim.notify('Does not find this type in kind')
-    end
+local function load_custom_kind()
+  if next(custom_kind) ~= nil then
+    for k, conf in pairs(custom_kind) do
+      local index = find_index_by_type(k)
+      if not index then
+        vim.notify('Does not find this type in kind')
+      end
 
-    if type(conf) == 'string' then
-      kind[index][3] = conf
-    end
+      if type(conf) == 'string' then
+        kind[index][3] = conf
+      end
 
-    if type(conf) == 'table' then
-      kind[index][2] = conf[1]
-      kind[index][3] = conf[2]
+      if type(conf) == 'table' then
+        kind[index][2] = conf[1]
+        kind[index][3] = conf[2]
+      end
     end
   end
 end
@@ -89,6 +91,10 @@ kind = setmetatable(kind, {
   __index = function(_, key)
     if key == 'gen_symbol_winbar_hi' then
       return gen_symbol_winbar_hi
+    end
+
+    if key == 'load_custom_kind' then
+      return load_custom_kind
     end
 
     if key == 'colors' then


### PR DESCRIPTION
## Current behavior
`custom_kind` would only be respected when symbols in winbar is enabled:
https://github.com/glepnir/lspsaga.nvim/blob/b59ff0d1752f7e9ef93363b71a2cd9b8f2011fec/lua/lspsaga/init.lua#L105-L108
Where `require('lspsaga.lspkind').gen_symbol_winbar_hi()` modified lspkind icons.

## Expected behavior
`custom_kind` would overwrite icons / colors in any occasion.

### Solution
Handle the `custom_kind` table separately.