### PR TITLE
feat: cache code action in lightbulb

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ code_action_num_shortcut = true,
 code_action_lightbulb = {
     enable = true,
     enable_in_insert = true,
+    cache_code_action = true,
     sign = true,
     update_time = 150,
     sign_priority = 20,
@@ -316,6 +317,12 @@ symbol_in_winbar = {
 }
 ```
 </details>
+
+## Module Contact
+
+* Enable `symbol_in_winbar` will make render outline faset.
+* Enable `code_action_lightbulb` will make code action fast.
+
 
 ## Customize Appearance
 

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -140,7 +140,23 @@ function Action:get_clients(results, options)
   end
 end
 
+function Action:actions_in_cache()
+  if not config.code_action_lightbulb.enable then
+    return false
+  end
+
+  if self.action_tuples and next(self.action_tuples) ~= nil then
+    return true
+  end
+end
+
 function Action:code_action()
+  local in_cache = self:actions_in_cache()
+  if in_cache then
+    self:action_callback()
+    return
+  end
+
   self.bufnr = api.nvim_get_current_buf()
   local diagnostics = vim.lsp.diagnostic.get_line_diagnostics(self.bufnr)
   local context = { diagnostics = diagnostics }
@@ -158,6 +174,12 @@ function Action:code_action()
 end
 
 function Action:range_code_action(context, start_pos, end_pos)
+  local in_cache = self:actions_in_cache()
+  if in_cache then
+    self:action_callback()
+    return
+  end
+
   self.bufnr = api.nvim_get_current_buf()
   vim.validate({ context = { context, 't', true } })
   context = context or { diagnostics = vim.lsp.diagnostic.get_line_diagnostics(self.bufnr) }

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -24,6 +24,7 @@ saga.config_values = {
   code_action_lightbulb = {
     enable = true,
     enable_in_insert = true,
+    cache_code_action = true,
     sign = true,
     update_time = 150,
     sign_priority = 40,


### PR DESCRIPTION
This can improve code action speed. new option

`cache_code_action` default is true.  disable it will not cache the code action.