### PR TITLE
DONT MERGE THIS STUPID PR INTO MAIN!!!!!

### DIFF
--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -73,7 +73,7 @@ function def:preview_definition()
     )
 
     local prompt = config.definition_preview_icon .. 'File: '
-    content = vim.list_extend({ prompt .. short_name .. ' [Ctrl + c] to quit', '' }, content)
+    content = vim.list_extend({ prompt .. short_name, '' }, content)
 
     local opts = {
       relative = 'cursor',

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -110,9 +110,11 @@ function def:preview_definition()
       desc = 'Auto close lspsaga definition preview window',
     })
 
-    vim.keymap.set('n', '<C-c>', function()
+    local quit_key = config.definition_preview_quit
+    vim.keymap.set('n', quit_key, function()
       if self.winid and api.nvim_win_is_valid(self.winid) then
         api.nvim_win_close(self.winid, true)
+        vim.cmd "set nohls"
       end
     end, { buffer = self.bufnr })
 

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -6,6 +6,9 @@ local path_sep = libs.path_sep
 local method = 'textDocument/definition'
 
 function def:preview_definition()
+
+  local search = vim.fn.expand('<cword>')
+
   if not libs.check_lsp_active() then
     return
   end
@@ -103,8 +106,11 @@ function def:preview_definition()
     if not vim.opt_local.modifiable:get() then
       vim.opt_local.modifiable = true
     end
+
     --set the initail cursor pos
-    api.nvim_win_set_cursor(self.winid, { 3, 1 })
+    -- api.nvim_win_set_cursor(self.winid, { 1, 1 })
+
+    vim.fn.search(search)
 
     api.nvim_create_autocmd({ 'CursorMoved', 'InsertEnter', 'BufHidden' }, {
       buffer = current_buf,

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -26,8 +26,7 @@ function Finder:lsp_finder()
   vim.cmd "let g:finder = expand('<cword>')"
   vim.cmd "let g:resume = @/"
   vim.cmd "set hls"
-  vim.cmd ":execute '/' . @0"
-  vim.cmd ":normal! N"
+  vim.cmd "let @/ = g:finder"
 
   if not libs.check_lsp_active() then
     return
@@ -784,7 +783,7 @@ function Finder:quit_float_window()
   end
 
   vim.cmd "set nohls"
-  vim.cmd ":execute '/' . g:resume"
+  vim.cmd "let @/ = g:resume"
 end
 
 function Finder:clear_tmp_data()

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -23,10 +23,9 @@ local msgs = {
 local Finder = {}
 
 function Finder:lsp_finder()
-  vim.cmd "let g:finder = expand('<cword>')"
   vim.cmd "let g:resume = @/"
   vim.cmd "set hls"
-  vim.cmd "let @/ = g:finder"
+  vim.cmd "let @/ = expand('<cword>')"
 
   if not libs.check_lsp_active() then
     return

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -23,6 +23,12 @@ local msgs = {
 local Finder = {}
 
 function Finder:lsp_finder()
+  vim.cmd "let g:finder = expand('<cword>')"
+  vim.cmd "let g:resume = @/"
+  vim.cmd "set hls"
+  vim.cmd ":execute '/' . @0"
+  vim.cmd ":normal! N"
+
   if not libs.check_lsp_active() then
     return
   end
@@ -776,6 +782,9 @@ function Finder:quit_float_window()
     api.nvim_win_close(self.titlebar_winid, true)
     self.titlebar_winid = nil
   end
+
+  vim.cmd "set nohls"
+  vim.cmd ":execute '/' . g:resume"
 end
 
 function Finder:clear_tmp_data()

--- a/lua/lspsaga/floaterm.lua
+++ b/lua/lspsaga/floaterm.lua
@@ -1,6 +1,7 @@
 local api = vim.api
 local window = require('lspsaga.window')
 local term = {}
+local config = require('lspsaga').config_values
 
 function term:open_float_terminal(command)
   local cmd = command or os.getenv('SHELL')
@@ -30,7 +31,7 @@ function term:open_float_terminal(command)
   local content_opts = {
     contents = {},
     enter = true,
-    winblend = 0,
+    winblend = config.float_term.winblend,
   }
   if self.term_bufnr then
     content_opts.bufnr = self.term_bufnr
@@ -54,7 +55,9 @@ end
 function term:close_float_terminal()
   if self.term_winid and api.nvim_win_is_valid(self.term_winid) then
     api.nvim_win_hide(self.term_winid)
-    api.nvim_win_hide(self.shadow_winid)
+    if config.float_term.shadow_background then
+      api.nvim_win_hide(self.shadow_winid)
+    end
   end
 end
 

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -35,7 +35,7 @@ saga.config_values = {
     virtual_text = true,
   },
   max_preview_lines = 10,
-  definition_preview_quit = '<ESC>',
+  definition_preview_quit = '<C-c>',
   scroll_in_preview = {
     scroll_down = '<C-f>',
     scroll_up = '<C-b>',

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -7,6 +7,10 @@ saga.saga_augroup = api.nvim_create_augroup('Lspsaga', { clear = true })
 saga.config_values = {
   border_style = 'single',
   saga_winblend = 0,
+  float_term = {
+    winblend = 25,
+    shadow_background = true,
+  },
   -- when cusor in saga float window
   -- config these keys to move
   move_in_saga = {

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -31,6 +31,7 @@ saga.config_values = {
     virtual_text = true,
   },
   max_preview_lines = 10,
+  definition_preview_quit = '<ESC>',
   scroll_in_preview = {
     scroll_down = '<C-f>',
     scroll_up = '<C-b>',

--- a/lua/lspsaga/lspkind.lua
+++ b/lua/lspsaga/lspkind.lua
@@ -14,15 +14,15 @@ local colors = {
 }
 
 local kind = {
-  [1] = { 'File', ' ', colors.fg },
-  [2] = { 'Module', ' ', colors.blue },
-  [3] = { 'Namespace', ' ', colors.orange },
-  [4] = { 'Package', ' ', colors.violet },
-  [5] = { 'Class', ' ', colors.violet },
-  [6] = { 'Method', ' ', colors.violet },
-  [7] = { 'Property', ' ', colors.cyan },
-  [8] = { 'Field', ' ', colors.teal },
-  [9] = { 'Constructor', ' ', colors.blue },
+  [1]  = { 'File', ' ', colors.fg },
+  [2]  = { 'Module', ' ', colors.blue },
+  [3]  = { 'Namespace', ' ', colors.orange },
+  [4]  = { 'Package', ' ', colors.violet },
+  [5]  = { 'Class', ' ', colors.violet },
+  [6]  = { 'Method', ' ', colors.violet },
+  [7]  = { 'Property', ' ', colors.cyan },
+  [8]  = { 'Field', ' ', colors.teal },
+  [9]  = { 'Constructor', ' ', colors.blue },
   [10] = { 'Enum', '了', colors.green },
   [11] = { 'Interface', ' ', colors.orange },
   [12] = { 'Function', ' ', colors.violet },
@@ -81,7 +81,7 @@ local function gen_symbol_winbar_hi()
   local winbar_sep = 'LspSagaWinbarSep'
 
   for _, v in pairs(kind) do
-    api.nvim_set_hl(0, prefix .. v[1], { fg = v[3] })
+    api.nvim_set_hl(0, prefix .. v[1], { fg = v[3], bold = true, italic = true })
   end
   api.nvim_set_hl(0, winbar_sep, { fg = '#d16d9e' })
   api.nvim_set_hl(0, prefix .. 'File', { fg = colors.fg, bold = true })

--- a/lua/lspsaga/lspkind.lua
+++ b/lua/lspsaga/lspkind.lua
@@ -81,7 +81,7 @@ local function gen_symbol_winbar_hi()
   local winbar_sep = 'LspSagaWinbarSep'
 
   for _, v in pairs(kind) do
-    api.nvim_set_hl(0, prefix .. v[1], { fg = v[3], bold = true, italic = true })
+    api.nvim_set_hl(0, prefix .. v[1], { fg = v[3] })
   end
   api.nvim_set_hl(0, winbar_sep, { fg = '#d16d9e' })
   api.nvim_set_hl(0, prefix .. 'File', { fg = colors.fg, bold = true })

--- a/lua/lspsaga/window.lua
+++ b/lua/lspsaga/window.lua
@@ -151,7 +151,7 @@ function M.create_win_with_border(content_opts, opts)
 
   local contents, filetype = content_opts.contents, content_opts.filetype
   local enter = content_opts.enter or false
-  local highlight = content_opts.highlight or 'LspFloatWinBorder'
+  local highlight = content_opts.highlight or 'LspSagaTermBorder'
   opts = opts or {}
   opts = generate_win_opts(contents, opts)
   opts.border = content_opts.border or get_border_style(config.border_style, highlight)
@@ -193,6 +193,8 @@ function M.create_win_with_border(content_opts, opts)
   if config.symbol_in_winbar.enable or config.symbol_in_winbar.in_custom then
     api.nvim_win_set_option(winid, 'winbar', '')
   end
+
+  -- vim.fn.search(vim.fn.expand('<cword>'))
 
   return bufnr, winid
 end


### PR DESCRIPTION
This is a stupid PR.
Though I'm the freshman for neovim, so the code in this PR is terrible, but I wish can improve lspsaga as best as I can.

I ADD some stuff might be useful, but the code is definitely not the best, some implements is stupid.

New feature:
1. ADD float term config
```lua
    float_term = {
        winblend = 25,                                 -- winblen of float_term
        shadow_background = false,           -- wether show dark background
    },
```

2. definition preview quit key config
```
definition_preview_quit = '<C-c>',      -- default to <C-c>
```

3. autojump on symbol in preview window
this is implements by this
```
local res = vim.fn.expand('<cword>')
open definition preview window
vim.fn.search(res) to jump on result
...
```

4. auto highlight finder's result without affect any native register
this is implements by
```
let g:search = @/
set hls
let @/ = expand('<cword>')
open_finder with result highlight in search
...
close_finder with let @/ = g:search
set nohls
```

BUGS:
1. if float_term is exit by user not hind by lspsaga, re open it will cause error (so we might need two option like open_new / resume floating window)

It's just my idea, I'm just trying to improve lspsaga's experience ( the way I implement it's not the best way but I keep trying)

Hope it can help you, even if it reduces the workload a little, wish you have a good day sir :100: 

best wishes