### PR TITLE
add diagnostics_jump_prev/next_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ keymap("n", "<leader>cd", "<cmd>Lspsaga show_cursor_diagnostics<CR>", { silent =
 -- Diagnsotic jump can use `<c-o>` to jump back
 keymap("n", "[e", "<cmd>Lspsaga diagnostic_jump_prev<CR>", { silent = true })
 keymap("n", "]e", "<cmd>Lspsaga diagnostic_jump_next<CR>", { silent = true })
+keymap("n", "[E", "<cmd>Lspsaga diagnostic_jump_prev_error<CR>", { silent = true })
+keymap("n", "]E", "<cmd>Lspsaga diagnostic_jump_next_error<CR>", { silent = true })
 
 -- Only jump to error
 keymap("n", "[E", function()

--- a/lua/lspsaga/command.lua
+++ b/lua/lspsaga/command.lua
@@ -21,6 +21,12 @@ local subcommands = {
   show_line_diagnostics = diagnostic.show_line_diagnostics,
   diagnostic_jump_next = diagnostic.goto_next,
   diagnostic_jump_prev = diagnostic.goto_prev,
+  diagnostic_jump_next_error = function()
+    diagnostic.goto_next({severity=diagnostic.severity.ERROR})
+  end,
+  diagnostic_jump_prev_error = function()
+    diagnostic.goto_prev({severity=diagnostic.severity.ERROR})
+  end,
   code_action = function()
     codeaction:code_action()
   end,


### PR DESCRIPTION
add diagnostics_jump_prev/next_error, I have tested it.
In my config
```
map('n', '[e', [[<cmd>Lspsaga diagnostic_jump_prev_error<Cr>]], opts)
map('n', ']e', [[<cmd>Lspsaga diagnostic_jump_next_error<Cr>]], opts)
map('n', '[d', [[<cmd>Lspsaga diagnostic_jump_prev<Cr>]], opts)
map('n', ']d', [[<cmd>Lspsaga diagnostic_jump_next<Cr>]], opts)


```