### PR TITLE
Version 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ saga.init_lsp_saga()
 keymap("n", "gh", "<cmd>Lspsaga lsp_finder<CR>", { silent = true })
 
 -- Code action
-keymap("n", "<leader>ca", "<cmd>Lspsaga code_action<CR>", { silent = true })
-keymap("v", "<leader>ca", "<cmd><C-U>Lspsaga range_code_action<CR>", { silent = true })
+keymap({"n","v"}, "<leader>ca", "<cmd>Lspsaga code_action<CR>", { silent = true })
 
 -- Rename
 keymap("n", "gr", "<cmd>Lspsaga rename<CR>", { silent = true })

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ keymap({"n","v"}, "<leader>ca", "<cmd>Lspsaga code_action<CR>", { silent = true 
 -- Rename
 keymap("n", "gr", "<cmd>Lspsaga rename<CR>", { silent = true })
 
--- Definition preview
-keymap("n", "gd", "<cmd>Lspsaga preview_definition<CR>", { silent = true })
+-- Peek Definition
+keymap("n", "gd", "<cmd>Lspsaga peek_definition<CR>", { silent = true })
 
 -- Show line diagnostics
 keymap("n", "<leader>cd", "<cmd>Lspsaga show_line_diagnostics<CR>", { silent = true })
@@ -180,7 +180,6 @@ definition_action_keys = {
 },
 rename_action_quit = "<C-c>",
 rename_in_select = true,
-definition_preview_icon = "  ",
 -- show symbols in winbar must nightly
 symbol_in_winbar = {
     in_custom = false,
@@ -365,10 +364,6 @@ The available highlight groups you can find in [here](./plugin/lspsaga.lua).
 <details>
 <summary>lsp finder</summary>
 
-Finder Title work with neovim 0.8 +
-
-NOTE: This requires ```filetypes``` and ```root_dir``` set in the  LSP server ```config``` object. So for [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls) users, even if you are loading the plugin as ```ftplugin``` or with ```FileType java``` autocmd, set ```filetypes``` in the ```config``` object.
-  
 <div align='center'>
 <img
 src="https://user-images.githubusercontent.com/41671631/181253960-cef49f9d-db8b-4b04-92d8-cb6322749414.png" />

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -1,4 +1,4 @@
-local api,util = vim.api,vim.lsp.util
+local api, util = vim.api, vim.lsp.util
 local window = require('lspsaga.window')
 local config = require('lspsaga').config_values
 local wrap = require('lspsaga.wrap')

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -1,4 +1,4 @@
-local api = vim.api
+local api,util = vim.api,vim.lsp.util
 local window = require('lspsaga.window')
 local config = require('lspsaga').config_values
 local wrap = require('lspsaga.wrap')
@@ -150,11 +150,40 @@ function Action:actions_in_cache()
   end
 end
 
-function Action:code_action()
+function Action:code_action(options)
   self.bufnr = api.nvim_get_current_buf()
   local diagnostics = vim.lsp.diagnostic.get_line_diagnostics(self.bufnr)
   local context = { diagnostics = diagnostics }
-  local params = vim.lsp.util.make_range_params()
+  local params
+  local mode = api.nvim_get_mode().mode
+  print(mode)
+  options = options or {}
+  if options.range then
+    assert(type(options.range) == 'table', 'code_action range must be a table')
+    local start = assert(options.range.start, 'range must have a `start` property')
+    local end_ = assert(options.range['end'], 'range must have a `end` property')
+    params = util.make_given_range_params(start, end_)
+  elseif mode == 'v' or mode == 'V' then
+    -- [bufnum, lnum, col, off]; both row and column 1-indexed
+    local start = vim.fn.getpos('v')
+    local end_ = vim.fn.getpos('.')
+    local start_row = start[2]
+    local start_col = start[3]
+    local end_row = end_[2]
+    local end_col = end_[3]
+
+    -- A user can start visual selection at the end and move backwards
+    -- Normalize the range to start < end
+    if start_row == end_row and end_col < start_col then
+      end_col, start_col = start_col, end_col
+    elseif end_row < start_row then
+      start_row, end_row = end_row, start_row
+      start_col, end_col = end_col, start_col
+    end
+    params = util.make_given_range_params({ start_row, start_col - 1 }, { end_row, end_col - 1 })
+  else
+    params = util.make_range_params()
+  end
   params.context = context
   if self.ctx == nil then
     self.ctx = {}
@@ -166,29 +195,6 @@ function Action:code_action()
     self:action_callback()
     return
   end
-
-  vim.lsp.buf_request_all(self.bufnr, method, params, function(results)
-    self:get_clients(results)
-    self:action_callback()
-  end)
-end
-
-function Action:range_code_action(context, start_pos, end_pos)
-  local in_cache = self:actions_in_cache()
-  if in_cache then
-    self:action_callback()
-    return
-  end
-
-  self.bufnr = api.nvim_get_current_buf()
-  vim.validate({ context = { context, 't', true } })
-  context = context or { diagnostics = vim.lsp.diagnostic.get_line_diagnostics(self.bufnr) }
-  local params = vim.lsp.util.make_given_range_params(start_pos, end_pos)
-  params.context = context
-  if self.ctx == nil then
-    self.ctx = {}
-  end
-  self.ctx = { bufnr = self.bufnr, method = method, params = params }
 
   vim.lsp.buf_request_all(self.bufnr, method, params, function(results)
     self:get_clients(results)

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -156,7 +156,6 @@ function Action:code_action(options)
   local context = { diagnostics = diagnostics }
   local params
   local mode = api.nvim_get_mode().mode
-  print(mode)
   options = options or {}
   if options.range then
     assert(type(options.range) == 'table', 'code_action range must be a table')

--- a/lua/lspsaga/command.lua
+++ b/lua/lspsaga/command.lua
@@ -24,9 +24,6 @@ local subcommands = {
   code_action = function()
     codeaction:code_action()
   end,
-  range_code_action = function()
-    codeaction:range_code_action()
-  end,
   open_floaterm = function(cmd)
     require('lspsaga.floaterm'):open_float_terminal(cmd)
   end,

--- a/lua/lspsaga/command.lua
+++ b/lua/lspsaga/command.lua
@@ -9,7 +9,13 @@ local subcommands = {
     finder:lsp_finder()
   end,
   preview_definition = function()
-    require('lspsaga.definition'):preview_definition()
+    vim.notify(
+      'preview_definition will be removed after three days,Please use peek_definition instead of',
+      vim.log.levels.WARN
+    )
+  end,
+  peek_definition = function()
+    require('lspsaga.definition'):peek_definition()
   end,
   rename = function()
     lsprename:lsp_rename()
@@ -23,6 +29,12 @@ local subcommands = {
   diagnostic_jump_prev = diagnostic.goto_prev,
   code_action = function()
     codeaction:code_action()
+  end,
+  range_code_action = function()
+    vim.notify(
+      'range_code_action will be removed after three days,Please use code_action instead of. check example config',
+      vim.log.levels.WARN
+    )
   end,
   open_floaterm = function(cmd)
     require('lspsaga.floaterm'):open_float_terminal(cmd)

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -129,8 +129,10 @@ function def:peek_definition()
 
     local quit = config.definition_action_keys.quit
     vim.keymap.set('n', quit, function()
+      api.nvim_buf_clear_namespace(bufnr,def_win_ns,start_line-1,start_line)
       if self.winid and api.nvim_win_is_valid(self.winid) then
         api.nvim_win_close(self.winid, true)
+        api.nvim_win_close(self.title_winid, true)
         vim.keymap.del('n', quit, { buffer = bufnr })
       end
     end, { buffer = bufnr })

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -50,7 +50,7 @@ function def:peek_definition()
   local current_buf = api.nvim_get_current_buf()
   lsp.buf_request_all(current_buf, method, params, function(results)
     if not results or next(results) == nil then
-      vim.notify('[Lspsaga] response of request method ' .. method .. ' is nil from ')
+      vim.notify('[Lspsaga] response of request method ' .. method .. ' is nil')
       return
     end
 
@@ -62,7 +62,7 @@ function def:peek_definition()
     end
 
     if not result then
-      vim.notify('[Lspsaga] response of request method ' .. method .. ' is nil from ')
+      vim.notify('[Lspsaga] response of request method ' .. method .. ' is nil')
       return
     end
 
@@ -113,23 +113,19 @@ function def:peek_definition()
     api.nvim_win_set_cursor(self.winid, { start_line + 1, start_char_pos })
     vim.cmd('normal! zt')
 
+    local def_win_ns = api.nvim_create_namespace('DefinitionWinNs')
     api.nvim_buf_add_highlight(
       bufnr,
-      0,
+      def_win_ns,
       'DefinitionSearch',
       start_line,
       start_char_pos,
       end_char_pos
     )
 
-    --TODO: why this not work
-    local def_win_ns = api.nvim_create_namespace('DefinitionWinNs')
-    api.nvim_set_hl(def_win_ns, 'Normal', { fg = '#0d1a36' })
-    api.nvim_win_set_hl_ns(self.winid, def_win_ns)
-
     local quit = config.definition_action_keys.quit
     vim.keymap.set('n', quit, function()
-      api.nvim_buf_clear_namespace(bufnr,def_win_ns,start_line-1,start_line)
+      api.nvim_buf_clear_namespace(bufnr, def_win_ns, 0, -1)
       if self.winid and api.nvim_win_is_valid(self.winid) then
         api.nvim_win_close(self.winid, true)
         api.nvim_win_close(self.title_winid, true)

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -2,8 +2,42 @@ local libs, window = require('lspsaga.libs'), require('lspsaga.window')
 local config = require('lspsaga').config_values
 local lsp, fn, api = vim.lsp, vim.fn, vim.api
 local def = {}
-local path_sep = libs.path_sep
 local method = 'textDocument/definition'
+
+function def:render_title_win(opts, link)
+  local path_sep = libs.path_sep
+  local root_dir = libs.get_lsp_root_dir()
+  if not root_dir then
+    root_dir = ''
+  end
+
+  local short_name
+  if link:find(root_dir, 1, true) then
+    short_name = link:sub(root_dir:len() + 2)
+  else
+    local _split = vim.split(link, path_sep)
+    if #_split >= 4 then
+      short_name = table.concat(_split, path_sep, #_split - 2, #_split)
+    end
+  end
+
+  local content_opts = {
+    contents = { '   Definition: ' .. short_name .. ' ' },
+    border = 'none',
+  }
+  self.title_bufnr, self.title_winid = window.create_win_with_border(content_opts, opts)
+  local ns_id = api.nvim_create_namespace('LspsagaDefinition')
+  api.nvim_buf_set_extmark(self.title_bufnr, ns_id, 0, 0, {
+    virt_text = { { '┃', 'DefinitionArrow' }, { ' ', 'DefinitionArrow' } },
+    virt_text_pos = 'overlay',
+  })
+  api.nvim_buf_set_extmark(self.title_bufnr, ns_id, 0, 0, {
+    virt_text = { { ' ', 'DefinitionArrow' }, { '┃', 'DefinitionArrow' } },
+    virt_text_pos = 'eol',
+  })
+
+  api.nvim_buf_add_highlight(self.title_bufnr, 0, 'DefinitionFile', 0, 0, -1)
+end
 
 function def:preview_definition()
   if not libs.check_lsp_active() then
@@ -38,21 +72,6 @@ function def:preview_definition()
     end
     local bufnr = vim.uri_to_bufnr(uri)
     local link = vim.uri_to_fname(uri)
-    local short_name
-    local root_dir = libs.get_lsp_root_dir()
-    if not root_dir then
-      root_dir = ''
-    end
-
-    -- reduce filename length by root_dir or home dir
-    if link:find(root_dir, 1, true) then
-      short_name = link:sub(root_dir:len() + 2)
-    else
-      local _split = vim.split(link, path_sep)
-      if #_split >= 4 then
-        short_name = table.concat(_split, path_sep, #_split - 2, #_split)
-      end
-    end
 
     if not vim.api.nvim_buf_is_loaded(bufnr) then
       fn.bufload(bufnr)
@@ -61,9 +80,7 @@ function def:preview_definition()
     local range = result[1].targetRange or result[1].range
     local start_line = range.start.line
     local start_char_pos = range.start.character
-
-    local prompt = config.definition_preview_icon .. 'File: '
-    local quit = config.definition_action_keys.quit
+    local end_char_pos = range['end'].character
 
     local opts = {
       relative = 'cursor',
@@ -71,11 +88,16 @@ function def:preview_definition()
     }
     local WIN_WIDTH = api.nvim_get_option('columns')
     local max_width = math.floor(WIN_WIDTH * 0.6)
-    local max_height = math.floor(vim.o.lines * 0.6)
+    local max_height = math.floor(vim.o.lines * 0.4)
 
     opts.width = max_width
     opts.height = max_height
 
+    opts = lsp.util.make_floating_popup_options(max_width, max_height, opts)
+
+    self:render_title_win(opts, link)
+
+    opts.row = opts.row + 1
     local content_opts = {
       contents = {},
       filetype = filetype,
@@ -89,13 +111,38 @@ function def:preview_definition()
     api.nvim_win_set_option(self.winid, 'winbar', '')
     --set the initail cursor pos
     api.nvim_win_set_cursor(self.winid, { start_line + 1, start_char_pos })
+    vim.cmd('normal! zt')
 
+    api.nvim_buf_add_highlight(
+      bufnr,
+      0,
+      'DefinitionSearch',
+      start_line,
+      start_char_pos,
+      end_char_pos
+    )
+
+    --TODO: why this not work
+    local def_win_ns = api.nvim_create_namespace('DefinitionWinNs')
+    api.nvim_set_hl(def_win_ns, 'Normal', { fg = '#0d1a36' })
+    api.nvim_win_set_hl_ns(self.winid, def_win_ns)
+
+    local quit = config.definition_action_keys.quit
     vim.keymap.set('n', quit, function()
       if self.winid and api.nvim_win_is_valid(self.winid) then
         api.nvim_win_close(self.winid, true)
         vim.keymap.del('n', quit, { buffer = bufnr })
       end
     end, { buffer = bufnr })
+
+    api.nvim_create_autocmd('QuitPre', {
+      once = true,
+      callback = function()
+        if self.title_winid and api.nvim_win_is_valid(self.title_winid) then
+          api.nvim_win_close(self.title_winid, true)
+        end
+      end,
+    })
   end)
 end
 

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -57,21 +57,9 @@ function def:preview_definition()
     if not vim.api.nvim_buf_is_loaded(bufnr) then
       fn.bufload(bufnr)
     end
-    local range = result[1].targetRange or result[1].range
-    local start_line = range.start.line
-
-    local start_char_pos = range.start.character
-
-    local content = vim.api.nvim_buf_get_lines(
-      bufnr,
-      start_line,
-      range['end'].line + 1 + config.max_preview_lines,
-      false
-    )
 
     local prompt = config.definition_preview_icon .. 'File: '
     local quit = config.definition_action_keys.quit
-    content = vim.list_extend({ prompt .. short_name .. ' ' .. quit .. ' to quit', '' }, content)
 
     local opts = {
       relative = 'cursor',
@@ -80,65 +68,59 @@ function def:preview_definition()
     local WIN_WIDTH = api.nvim_get_option('columns')
     local max_width = math.floor(WIN_WIDTH * 0.6)
     local max_height = math.floor(vim.o.lines * 0.6)
-    local width, _ = vim.lsp.util._make_floating_popup_size(content, opts)
 
-    if width > max_width then
-      opts.width = max_width
-    end
-
-    if #content > max_height then
-      opts.height = max_height
-    end
+    opts.width = max_width
+    opts.height = max_height
 
     local content_opts = {
-      contents = content,
+      contents = {},
       filetype = filetype,
       enter = true,
       highlight = 'LspSagaDefPreviewBorder',
     }
 
     self.bufnr, self.winid = window.create_win_with_border(content_opts, opts)
-    if not vim.opt_local.modifiable:get() then
-      vim.opt_local.modifiable = true
-    end
+    vim.opt_local.modifiable = true
+    api.nvim_win_set_buf(0,bufnr)
+    api.nvim_win_set_option(self.winid,'winbar',"")
     --set the initail cursor pos
-    api.nvim_win_set_cursor(self.winid, { 3, start_char_pos })
+    -- api.nvim_win_set_cursor(self.winid, { 3, start_char_pos })
 
-    api.nvim_create_autocmd({ 'CursorMoved', 'InsertEnter', 'BufHidden' }, {
-      buffer = current_buf,
-      once = true,
-      callback = function()
-        if self.winid ~= nil then
-          window.nvim_close_valid_window(self.winid)
-        end
-        self:clear_tmp_data()
-      end,
-      desc = 'Auto close lspsaga definition preview window',
-    })
+    -- api.nvim_create_autocmd({ 'CursorMoved', 'InsertEnter', 'BufHidden' }, {
+    --   buffer = current_buf,
+    --   once = true,
+    --   callback = function()
+    --     if self.winid ~= nil then
+    --       window.nvim_close_valid_window(self.winid)
+    --     end
+    --     self:clear_tmp_data()
+    --   end,
+    --   desc = 'Auto close lspsaga definition preview window',
+    -- })
 
-    vim.keymap.set('n', quit, function()
-      if self.winid and api.nvim_win_is_valid(self.winid) then
-        api.nvim_win_close(self.winid, true)
-      end
-    end, { buffer = self.bufnr })
+    -- vim.keymap.set('n', quit, function()
+    --   if self.winid and api.nvim_win_is_valid(self.winid) then
+    --     api.nvim_win_close(self.winid, true)
+    --   end
+    -- end, { buffer = bufnr })
 
-    api.nvim_buf_add_highlight(self.bufnr, -1, 'DefinitionPreviewIcon', 0, 0, #prompt - 1)
-    api.nvim_buf_add_highlight(
-      self.bufnr,
-      0,
-      'DefinitionPreviewFile',
-      0,
-      #prompt + 1,
-      #prompt + #short_name
-    )
-    api.nvim_buf_add_highlight(
-      self.bufnr,
-      -1,
-      'DefinitionPreviewTip',
-      0,
-      #prompt + #short_name + 2,
-      -1
-    )
+    -- api.nvim_buf_add_highlight(self.bufnr, -1, 'DefinitionPreviewIcon', 0, 0, #prompt - 1)
+    -- api.nvim_buf_add_highlight(
+    --   self.bufnr,
+    --   0,
+    --   'DefinitionPreviewFile',
+    --   0,
+    --   #prompt + 1,
+    --   #prompt + #short_name
+    -- )
+    -- api.nvim_buf_add_highlight(
+    --   self.bufnr,
+    --   -1,
+    --   'DefinitionPreviewTip',
+    --   0,
+    --   #prompt + #short_name + 2,
+    --   -1
+    -- )
   end)
 end
 

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -58,6 +58,10 @@ function def:preview_definition()
       fn.bufload(bufnr)
     end
 
+    local range = result[1].targetRange or result[1].range
+    local start_line = range.start.line
+    local start_char_pos = range.start.character
+
     local prompt = config.definition_preview_icon .. 'File: '
     local quit = config.definition_action_keys.quit
 
@@ -76,51 +80,22 @@ function def:preview_definition()
       contents = {},
       filetype = filetype,
       enter = true,
-      highlight = 'LspSagaDefPreviewBorder',
+      highlight = 'DefinitionBorder',
     }
 
     self.bufnr, self.winid = window.create_win_with_border(content_opts, opts)
     vim.opt_local.modifiable = true
-    api.nvim_win_set_buf(0,bufnr)
-    api.nvim_win_set_option(self.winid,'winbar',"")
+    api.nvim_win_set_buf(0, bufnr)
+    api.nvim_win_set_option(self.winid, 'winbar', '')
     --set the initail cursor pos
-    -- api.nvim_win_set_cursor(self.winid, { 3, start_char_pos })
+    api.nvim_win_set_cursor(self.winid, { start_line + 1, start_char_pos })
 
-    -- api.nvim_create_autocmd({ 'CursorMoved', 'InsertEnter', 'BufHidden' }, {
-    --   buffer = current_buf,
-    --   once = true,
-    --   callback = function()
-    --     if self.winid ~= nil then
-    --       window.nvim_close_valid_window(self.winid)
-    --     end
-    --     self:clear_tmp_data()
-    --   end,
-    --   desc = 'Auto close lspsaga definition preview window',
-    -- })
-
-    -- vim.keymap.set('n', quit, function()
-    --   if self.winid and api.nvim_win_is_valid(self.winid) then
-    --     api.nvim_win_close(self.winid, true)
-    --   end
-    -- end, { buffer = bufnr })
-
-    -- api.nvim_buf_add_highlight(self.bufnr, -1, 'DefinitionPreviewIcon', 0, 0, #prompt - 1)
-    -- api.nvim_buf_add_highlight(
-    --   self.bufnr,
-    --   0,
-    --   'DefinitionPreviewFile',
-    --   0,
-    --   #prompt + 1,
-    --   #prompt + #short_name
-    -- )
-    -- api.nvim_buf_add_highlight(
-    --   self.bufnr,
-    --   -1,
-    --   'DefinitionPreviewTip',
-    --   0,
-    --   #prompt + #short_name + 2,
-    --   -1
-    -- )
+    vim.keymap.set('n', quit, function()
+      if self.winid and api.nvim_win_is_valid(self.winid) then
+        api.nvim_win_close(self.winid, true)
+        vim.keymap.del('n', quit, { buffer = bufnr })
+      end
+    end, { buffer = bufnr })
   end)
 end
 

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -39,7 +39,7 @@ function def:render_title_win(opts, link)
   api.nvim_buf_add_highlight(self.title_bufnr, 0, 'DefinitionFile', 0, 0, -1)
 end
 
-function def:preview_definition()
+function def:peek_definition()
   if not libs.check_lsp_active() then
     return
   end

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -51,10 +51,11 @@ function diag:render_diagnostic_window(entry, option)
     entry.source = entry.source:gsub('%.', '')
   end
   local source = ' ' .. entry.source
-  wrap_message[1] = header .. ' ' .. diag_type[entry.severity]
+  local header_with_type = header .. diag_type[entry.severity]
+  local lnum_col = ' in ' .. '❮' .. entry.lnum + 1 .. ':' .. entry.col + 1 .. '❯'
   local lhs = self:code_action_map()
   local quickfix = lhs and 'QuickFixKey: ' .. lhs or ''
-  wrap_message[1] = wrap_message[1] .. ' ' .. quickfix
+  wrap_message[1] = header_with_type .. lnum_col .. ' ' .. quickfix
 
   local msgs = wrap.diagnostic_msg(entry.message .. source, max_width)
   for _, v in pairs(msgs) do
@@ -155,6 +156,15 @@ function diag:render_diagnostic_window(entry, option)
       virt_lines_above = false,
     })
   end
+
+  api.nvim_buf_add_highlight(
+    self.bufnr,
+    -1,
+    'DiagnosticLineCol',
+    0,
+    #header_with_type,
+    #header_with_type + #lnum_col + 1
+  )
 
   api.nvim_buf_add_highlight(
     self.bufnr,

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -335,7 +335,7 @@ function diag:show_diagnostics(opts, get_diagnostics)
   end
 
   api.nvim_buf_add_highlight(self.show_diag_bufnr, -1, 'LspSagaDiagnosticTruncateLine', 1, 0, -1)
-  local close_events = { 'CursorMoved', 'CursorMovedI', 'InsertEnter' }
+  local close_events = { 'CursorMoved', 'InsertEnter' }
 
   libs.close_preview_autocmd(current_buf, self.show_diag_winid, close_events)
   return self.show_diag_winid

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -59,7 +59,6 @@ saga.config_values = {
   },
   rename_action_quit = '<C-c>',
   rename_in_select = true,
-  definition_preview_icon = ' ',
   -- winbar must nightly
   symbol_in_winbar = {
     in_custom = false,

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -15,8 +15,6 @@ saga.config_values = {
   },
   -- Error,Warn,Info,Hint
   diagnostic_header = { ' ', ' ', ' ', ' ' },
-  show_diagnostic_source = true,
-  diagnostic_source_bracket = { '❴', '❵' },
   -- code action title icon
   code_action_icon = '💡',
   -- if true can press number to execute the codeaction in codeaction window

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -41,8 +41,6 @@ saga.config_values = {
     ref = ' ',
   },
   finder_request_timeout = 1500,
-  -- nvim 0.8 only
-  finder_preview_hl_ns = 0,
   finder_action_keys = {
     open = 'o',
     vsplit = 's',

--- a/lua/lspsaga/outline.lua
+++ b/lua/lspsaga/outline.lua
@@ -244,6 +244,10 @@ end
 
 ---@private
 local do_symbol_request = function()
+  if vim.bo.filetype == 'lspsagaoutline' then
+    return
+  end
+
   local bufnr = api.nvim_get_current_buf()
   local params = { textDocument = lsp.util.make_text_document_params(bufnr) }
   local client = libs.get_client_by_cap('documentSymbolProvider')

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -149,6 +149,10 @@ local render_symbol_winbar = function()
   end
   local symbols = symbar.symbol_cache[current_buf]
 
+  if not symbols then
+    return
+  end
+
   local winbar_elements = {}
 
   if config.click_support ~= false then

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -33,6 +33,7 @@ local do_symbol_request = function(callback)
   if client == nil then
     return
   end
+  symbar.pending_request = true
   client.request(method, params, callback, current_buf)
 end
 
@@ -143,11 +144,10 @@ local render_symbol_winbar = function()
 
   local winbar_val = config.show_file and not config.in_custom and symbar:get_file_name() or ''
 
-  local symbols = {}
-  if symbar.symbol_cache[current_buf] == nil then
+  if not symbar.symbol_cache[current_buf] and next(symbar.symbol_cache) == nil then
     return
   end
-  symbols = symbar.symbol_cache[current_buf][2]
+  local symbols = symbar.symbol_cache[current_buf]
 
   local winbar_elements = {}
 
@@ -168,12 +168,11 @@ local render_symbol_winbar = function()
   return winbar_val
 end
 
-function symbar:get_buf_symbol(force, ...)
-  force = force or false
-  local current_buf = api.nvim_get_current_buf()
-  if self.symbol_cache[current_buf] and self.symbol_cache[current_buf][1] and not force then
+function symbar:get_buf_symbol(...)
+  if self.pending_request then
     return
   end
+  local current_buf = api.nvim_get_current_buf()
 
   local arg = { ... }
   local fn
@@ -182,11 +181,12 @@ function symbar:get_buf_symbol(force, ...)
   end
 
   local _callback = function(_, result)
+    self.pending_request = false
     if not result then
       return
     end
 
-    self.symbol_cache[current_buf] = { true, result }
+    self.symbol_cache[current_buf] = result
 
     if fn ~= nil then
       fn()
@@ -199,7 +199,6 @@ function symbar:get_buf_symbol(force, ...)
       })
     end
   end
-
   do_symbol_request(_callback)
 end
 
@@ -212,24 +211,15 @@ end
 
 local symbol_buf_ids = {}
 
-local function symbol_events()
+function symbar:symbol_events()
   if not libs.check_lsp_active(false) then
     return
   end
 
   local current_buf = api.nvim_get_current_buf()
-  local cache = symbar.symbol_cache
+  self.pending_request = false
 
-  local update_symbols = function(force)
-    force = force or true
-    if cache[current_buf] == nil or next(cache[current_buf]) == nil or force then
-      symbar:get_buf_symbol(force, render_symbol_winbar)
-    else
-      render_symbol_winbar()
-    end
-  end
-
-  update_symbols(true)
+  self:get_buf_symbol(render_symbol_winbar)
 
   local symbol_group =
     api.nvim_create_augroup('LspsagaSymbol' .. tostring(current_buf), { clear = true })
@@ -238,7 +228,9 @@ local function symbol_events()
   api.nvim_create_autocmd('CursorMoved', {
     group = symbol_group,
     buffer = current_buf,
-    callback = update_symbols,
+    callback = function()
+      render_symbol_winbar()
+    end,
     desc = 'Lspsaga symbols',
   })
 
@@ -247,10 +239,10 @@ local function symbol_events()
     buffer = current_buf,
     callback = function()
       if config.in_custom then
-        symbar:get_buf_symbol(true)
-      else
-        symbar:get_buf_symbol(true, render_symbol_winbar)
+        self:get_buf_symbol()
+        return
       end
+      self:get_buf_symbol(render_symbol_winbar)
     end,
     desc = 'Lspsaga update symbols',
   })
@@ -258,6 +250,7 @@ local function symbol_events()
   api.nvim_buf_attach(current_buf, false, {
     on_detach = function()
       if symbol_buf_ids[current_buf] then
+        self:clear_cache()
         pcall(api.nvim_del_augroup_by_id, symbol_buf_ids[current_buf])
         rawset(symbol_buf_ids, current_buf, nil)
       end
@@ -268,7 +261,9 @@ end
 function symbar.config_symbol_autocmd()
   api.nvim_create_autocmd('LspAttach', {
     group = api.nvim_create_augroup('LspsagaSymbols', {}),
-    callback = symbol_events,
+    callback = function()
+      symbar:symbol_events()
+    end,
     desc = 'Lspsaga get and show symbols',
   })
 end

--- a/plugin/lspsaga.lua
+++ b/plugin/lspsaga.lua
@@ -27,6 +27,7 @@ local highlights = {
   FinderSpinnerBorder = { fg = '#51afef' },
   FinderSpinnerTitle = { fg = '#b33076', bold = true },
   FinderSpinner = { fg = '#b33076', bold = true },
+  FinderPreviewSearch = { link = 'Search' },
   -- definition
   DefinitionBorder = { fg = '#b3deef' },
   DefinitionArrow = { fg = '#ad475f' },

--- a/plugin/lspsaga.lua
+++ b/plugin/lspsaga.lua
@@ -29,6 +29,9 @@ local highlights = {
   FinderSpinner = { fg = '#b33076', bold = true },
   -- definition
   DefinitionBorder = { fg = '#b3deef' },
+  DefinitionArrow = { fg = '#ad475f' },
+  DefinitionSearch = { link = 'Search' },
+  DefinitionFile = { bg = '#151838' },
   -- hover
   LspSagaHoverBorder = { fg = '#f7bb3b' },
   LspSagaHoverTrunCateLine = { link = 'LspSagaHoverBorder' },

--- a/plugin/lspsaga.lua
+++ b/plugin/lspsaga.lua
@@ -28,10 +28,7 @@ local highlights = {
   FinderSpinnerTitle = { fg = '#b33076', bold = true },
   FinderSpinner = { fg = '#b33076', bold = true },
   -- definition
-  LspSagaDefPreviewBorder = { fg = '#b3deef' },
-  DefinitionPreviewIcon = { link = 'Title' },
-  DefinitionPreviewFile = { link = 'Define' },
-  DefinitionPreviewTip = { link = 'Comment' },
+  DefinitionBorder = { fg = '#b3deef' },
   -- hover
   LspSagaHoverBorder = { fg = '#f7bb3b' },
   LspSagaHoverTrunCateLine = { link = 'LspSagaHoverBorder' },

--- a/plugin/lspsaga.lua
+++ b/plugin/lspsaga.lua
@@ -53,6 +53,7 @@ local highlights = {
   LspSagaDiagnosticHeader = { fg = '#afd700' },
   DiagnosticQuickFix = { fg = '#4dd158', bold = true },
   DiagnosticMap = { fg = '#cf80ce' },
+  DiagnosticLineCol = { fg = '#73797e' },
   LspSagaDiagnosticTruncateLine = { link = 'LspSagaDiagnosticBorder' },
   ColInLineDiagnostic = { link = 'Comment' },
   -- signture help

--- a/plugin/lspsaga.lua
+++ b/plugin/lspsaga.lua
@@ -40,7 +40,7 @@ local highlights = {
   LspSagaRenameBorder = { fg = '#3bb6c4' },
   LspSagaRenameMatch = { link = 'Search' },
   -- diagnostic
-  LspSagaDiagnosticSource = { fg = '#FF8700' },
+  LspSagaDiagnosticSource = { link = 'Comment' },
   LspSagaDiagnosticError = { link = 'DiagnosticError' },
   LspSagaDiagnosticWarn = { link = 'DiagnosticWarn' },
   LspSagaDiagnosticInfo = { link = 'DiagnosticInfo' },
@@ -51,6 +51,8 @@ local highlights = {
   LspSagaHintTrunCateLine = { link = 'DiagnosticHint' },
   LspSagaDiagnosticBorder = { fg = '#CBA6F7' },
   LspSagaDiagnosticHeader = { fg = '#afd700' },
+  DiagnosticQuickFix = { fg = '#4dd158', bold = true },
+  DiagnosticMap = { fg = '#cf80ce' },
   LspSagaDiagnosticTruncateLine = { link = 'LspSagaDiagnosticBorder' },
   ColInLineDiagnostic = { link = 'Comment' },
   -- signture help


### PR DESCRIPTION
## Version 0.2.2

- fix symbolwinbar high memory usage
- `preview_definition` chang to `peek_definition` support edit definition file in floatwindow and highlight
- `code_action` support in visual mode .
- `finder` preview highlight current word.
-  show diagnostic source by default.
- add lspsaga codeaction keymap in diagnostic header

## Remove

-  remove `definition_preview_icon`  option
- remove `finder_preview_hl_ns`
- remove `diagnostic_source_bracket`
- remove `show_diagnostic_source` . 