### PR TITLE
Add link of mappings to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ server_filetype_map = {},
 
 <details>
 <summary> work with custom winbar/statusline </summary>
-  
+
 ```lua
 saga.init_lsp_saga({
     symbol_in_winbar = {
@@ -324,6 +324,9 @@ symbol_in_winbar = {
 * Enable `symbol_in_winbar` will make render outline faset.
 * Enable `code_action_lightbulb` will make code action fast.
 
+## Mappings
+
+Plugin does not provide mappings by default. However, you can bind mappings yourself. You can find examples in the [showcase](#showcase) section.
 
 ## Customize Appearance
 
@@ -367,7 +370,7 @@ The available highlight groups you can find in [here](./plugin/lspsaga.lua).
 Finder Title work with neovim 0.8 +
 
 NOTE: This requires ```filetypes``` and ```root_dir``` set in the  LSP server ```config``` object. So for [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls) users, even if you are loading the plugin as ```ftplugin``` or with ```FileType java``` autocmd, set ```filetypes``` in the ```config``` object.
-  
+
 <div align='center'>
 <img
 src="https://user-images.githubusercontent.com/41671631/181253960-cef49f9d-db8b-4b04-92d8-cb6322749414.png" />


### PR DESCRIPTION
The link to mappings had been removed from the README and has been reverted.
This link was necessary for me, so others may need it.