### PR TITLE
fix(definition): support peeking multiple definitions

### DIFF
--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -148,18 +148,20 @@ function def:peek_definition()
 end
 
 function def:apply_aciton_keys(scope, bufnr, pos)
-  local link, def_win_ns = scope.link, scope.def_win_ns
-  local maps = config.definition_action_keys
-
+  -- Save the current scope data
   if self[bufnr] == nil then
     self[bufnr] = {}
   end
   table.insert(self[bufnr], scope)
 
+  local maps = config.definition_action_keys
+
   for action, key in pairs(maps) do
     vim.keymap.set('n', key, function()
-      api.nvim_buf_clear_namespace(bufnr, def_win_ns, 0, -1)
       local curr_scope = self:find_current_scope()
+      local link, def_win_ns = curr_scope.link, curr_scope.def_win_ns
+
+      api.nvim_buf_clear_namespace(bufnr, def_win_ns, 0, -1)
 
       local non_quit_action = action ~= 'quit'
       self:close_window(curr_scope, { close_all = non_quit_action })
@@ -180,19 +182,19 @@ end
 function def:find_current_scope()
   local curr_winid = api.nvim_get_current_win()
 
-  local current_scope
+  local curr_scope
   for _, scopes in pairs(self) do
     if type(scopes) == 'table' then
       for _, scope in ipairs(scopes) do
         if scope.winid == curr_winid then
-          current_scope = scope
+          curr_scope = scope
           break
         end
       end
     end
   end
 
-  return current_scope
+  return curr_scope
 end
 
 -- Function to clear all the keymappings when there's no window

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -161,15 +161,15 @@ function def:apply_aciton_keys(scope, bufnr, pos)
       api.nvim_buf_clear_namespace(bufnr, def_win_ns, 0, -1)
       local curr_scope = self:find_current_scope()
 
-      local close_all = action ~= 'quit'
-      self:close_window(curr_scope, { close_all = close_all })
+      local non_quit_action = action ~= 'quit'
+      self:close_window(curr_scope, { close_all = non_quit_action })
 
-      if close_all then
+      if non_quit_action then
         vim.cmd(action .. ' ' .. link)
         api.nvim_win_set_cursor(0, { pos[1] + 1, pos[2] })
       end
 
-      self:clear_tmp_data(bufnr, curr_scope, { close_all = close_all })
+      self:clear_tmp_data(bufnr, curr_scope, { close_all = non_quit_action })
       self:clear_all_maps(bufnr)
     end, { buffer = bufnr })
   end

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -4,7 +4,8 @@ local lsp, fn, api = vim.lsp, vim.fn, vim.api
 local def = {}
 local method = 'textDocument/definition'
 
-function def:render_title_win(opts, link)
+function def:render_title_win(opts, scope)
+  local link = scope.link
   local path_sep = libs.path_sep
   local root_dir = libs.get_lsp_root_dir()
   if not root_dir then
@@ -25,21 +26,22 @@ function def:render_title_win(opts, link)
     contents = { '   Definition: ' .. short_name .. ' ' },
     border = 'none',
   }
-  self.title_bufnr, self.title_winid = window.create_win_with_border(content_opts, opts)
+  scope.title_bufnr, scope.title_winid = window.create_win_with_border(content_opts, opts)
   local ns_id = api.nvim_create_namespace('LspsagaDefinition')
-  api.nvim_buf_set_extmark(self.title_bufnr, ns_id, 0, 0, {
+  api.nvim_buf_set_extmark(scope.title_bufnr, ns_id, 0, 0, {
     virt_text = { { '┃', 'DefinitionArrow' }, { ' ', 'DefinitionArrow' } },
     virt_text_pos = 'overlay',
   })
-  api.nvim_buf_set_extmark(self.title_bufnr, ns_id, 0, 0, {
+  api.nvim_buf_set_extmark(scope.title_bufnr, ns_id, 0, 0, {
     virt_text = { { ' ', 'DefinitionArrow' }, { '┃', 'DefinitionArrow' } },
     virt_text_pos = 'eol',
   })
 
-  api.nvim_buf_add_highlight(self.title_bufnr, 0, 'DefinitionFile', 0, 0, -1)
+  api.nvim_buf_add_highlight(scope.title_bufnr, 0, 'DefinitionFile', 0, 0, -1)
 end
 
 function def:peek_definition()
+  local scope = {}
   if not libs.check_lsp_active() then
     return
   end
@@ -88,7 +90,7 @@ function def:peek_definition()
     end
 
     local bufnr = vim.uri_to_bufnr(uri)
-    self.link = vim.uri_to_fname(uri)
+    scope.link = vim.uri_to_fname(uri)
 
     if not vim.api.nvim_buf_is_loaded(bufnr) then
       fn.bufload(bufnr)
@@ -111,7 +113,7 @@ function def:peek_definition()
 
     opts = lsp.util.make_floating_popup_options(max_width, max_height, opts)
 
-    self:render_title_win(opts, self.link)
+    self:render_title_win(opts, scope)
 
     opts.row = opts.row + 1
     local content_opts = {
@@ -121,79 +123,163 @@ function def:peek_definition()
       highlight = 'DefinitionBorder',
     }
 
-    self.bufnr, self.winid = window.create_win_with_border(content_opts, opts)
+    scope.bufnr, scope.winid = window.create_win_with_border(content_opts, opts)
     vim.opt_local.modifiable = true
     api.nvim_win_set_buf(0, bufnr)
     if vim.fn.has('nvim-0.8') == 1 then
-      api.nvim_win_set_option(self.winid, 'winbar', '')
+      api.nvim_win_set_option(scope.winid, 'winbar', '')
     end
     --set the initail cursor pos
-    api.nvim_win_set_cursor(self.winid, { start_line + 1, start_char_pos })
+    api.nvim_win_set_cursor(scope.winid, { start_line + 1, start_char_pos })
     vim.cmd('normal! zt')
 
-    self.def_win_ns = api.nvim_create_namespace('DefinitionWinNs')
+    scope.def_win_ns = api.nvim_create_namespace('DefinitionWinNs-' .. scope.bufnr)
     api.nvim_buf_add_highlight(
       bufnr,
-      self.def_win_ns,
+      scope.def_win_ns,
       'DefinitionSearch',
       start_line,
       start_char_pos,
       end_char_pos
     )
 
-    self:apply_aciton_keys(bufnr, { start_line, start_char_pos })
-
-    api.nvim_create_autocmd('QuitPre', {
-      once = true,
-      callback = function()
-        if self.title_winid and api.nvim_win_is_valid(self.title_winid) then
-          api.nvim_win_close(self.title_winid, true)
-        end
-      end,
-    })
+    self:apply_aciton_keys(scope, bufnr, { start_line, start_char_pos })
   end)
 end
 
-function def:apply_aciton_keys(bufnr, pos)
+function def:apply_aciton_keys(scope, bufnr, pos)
+  local link, def_win_ns = scope.link, scope.def_win_ns
   local maps = config.definition_action_keys
 
-  local del_all_maps = function()
-    for _, key in pairs(maps) do
-      vim.keymap.del('n', key, { buffer = bufnr })
-    end
+  if self[bufnr] == nil then
+    self[bufnr] = {}
   end
+  table.insert(self[bufnr], scope)
 
   for action, key in pairs(maps) do
     vim.keymap.set('n', key, function()
-      api.nvim_buf_clear_namespace(bufnr, self.def_win_ns, 0, -1)
-      del_all_maps()
-      self:close_window()
-      if bufnr ~= api.nvim_get_current_buf() then
-        api.nvim_buf_delete(bufnr, { force = true })
-      end
-      if action ~= 'quit' then
-        vim.cmd(action .. ' ' .. self.link)
+      api.nvim_buf_clear_namespace(bufnr, def_win_ns, 0, -1)
+      local curr_scope = self:find_current_scope()
+
+      local close_all = action ~= 'quit'
+      self:close_window(curr_scope, { close_all = close_all })
+
+      if close_all then
+        vim.cmd(action .. ' ' .. link)
         api.nvim_win_set_cursor(0, { pos[1] + 1, pos[2] })
       end
-      self:clear_tmp_data()
+
+      self:clear_tmp_data(bufnr, curr_scope, { close_all = close_all })
+      self:clear_all_maps(bufnr)
     end, { buffer = bufnr })
   end
 end
 
-function def:close_window()
-  if self.bufnr and api.nvim_buf_is_loaded(self.bufnr) then
-    api.nvim_buf_delete(self.bufnr, { force = true })
+-- Function to find the scope data for the current window
+-- @return table
+function def:find_current_scope()
+  local curr_winid = api.nvim_get_current_win()
+
+  local current_scope
+  for _, scopes in pairs(self) do
+    if type(scopes) == 'table' then
+      for _, scope in ipairs(scopes) do
+        if scope.winid == curr_winid then
+          current_scope = scope
+          break
+        end
+      end
+    end
   end
-  if self.winid and api.nvim_win_is_valid(self.winid) then
-    api.nvim_win_close(self.winid, true)
-    api.nvim_win_close(self.title_winid, true)
+
+  return current_scope
+end
+
+-- Function to clear all the keymappings when there's no window
+-- @param bufnr - The buffer number that those keymappings set for
+function def:clear_all_maps(bufnr)
+  local scopes = self[bufnr]
+  local maps = config.definition_action_keys
+
+  if scopes == nil or next(scopes) == nil then
+    if api.nvim_buf_is_valid(bufnr) then
+      for _, key in pairs(maps) do
+        vim.keymap.del('n', key, { buffer = bufnr })
+      end
+    end
   end
 end
 
-function def:clear_tmp_data()
-  for i, data in pairs(self) do
-    if type(data) ~= 'function' then
-      self[i] = nil
+-- Function to close the given window
+-- @param curr_scope - Scope data for the current window
+-- @param opts       - Options including `close_all`
+function def:close_window(curr_scope, opts)
+  opts = opts or {}
+  local curr_bufnr = api.nvim_get_current_buf()
+
+  local close_scope = function(item)
+    local bufnr, winid, title_winid = item.bufnr, item.winid, item.title_winid
+    if bufnr and api.nvim_buf_is_loaded(bufnr) then
+      api.nvim_buf_delete(bufnr, { force = true })
+    end
+
+    for _, each_winid in ipairs({ winid, title_winid }) do
+      if api.nvim_win_is_valid(each_winid) then
+        api.nvim_win_close(each_winid, true)
+      end
+    end
+  end
+
+  if opts.close_all then
+    self:process_all_scopes(function(bufnr, scopes)
+      for _, item in ipairs(scopes) do
+        close_scope(item)
+      end
+
+      if bufnr ~= curr_bufnr then
+        api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end)
+  elseif curr_scope ~= nil then
+    close_scope(curr_scope)
+  end
+end
+
+-- Function to clear the tmp data on triggering the keymap
+-- @param bufnr       - Current buffer number
+-- @param curr_scope  - Scope data for the current window
+-- @param opts        - Options including `close_all`
+function def:clear_tmp_data(bufnr, curr_scope, opts)
+  opts = opts or {}
+
+  if opts.close_all then
+    self:process_all_scopes(function(key, _)
+      self[key] = nil
+    end)
+  elseif curr_scope ~= nil then
+    local scopes = self[bufnr]
+
+    local matched_index
+    if scopes ~= nil then
+      for i, item in ipairs(scopes) do
+        if item.winid == curr_scope.winid then
+          matched_index = i
+        end
+      end
+
+      if matched_index ~= nil then
+        table.remove(scopes, matched_index)
+      end
+    end
+  end
+end
+
+-- Function to iterate all the scopes with given callback function
+-- @param cb - The callback function for each scope
+function def:process_all_scopes(cb)
+  for bufnr, scopes in pairs(self) do
+    if type(scopes) == 'table' and api.nvim_buf_is_valid(bufnr) then
+      cb(bufnr, scopes)
     end
   end
 end


### PR DESCRIPTION
1. Peeking definitions within the same buffer
- [x] Only remove the keymappings when all the related preview windows are closed
- [x] Keep the definition windows relationships based on the buffer ID

2. Peeking definitions across buffers/files
- [x] Only remove the keymappings for the closing buffer

3. edit/split/vsplit/tabe
- [x] Close all the windows and non-related buffers when triggering edit/split/vsplit/tabe

https://user-images.githubusercontent.com/12182069/190087724-c065774a-b551-4e40-8a79-c1e7315e716f.mov


