### PR TITLE
fix(CI): Broken workflow (ELF not found).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Stylua
-        uses: JohnnyMorganz/stylua-action@1.0.0
+        uses: JohnnyMorganz/stylua-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --check .


### PR DESCRIPTION
This commit fixed the problem with formatting CI. Currently incorrect artifact was chosen due to the introduction of `linux-aarch64` artifacts of latest `stylua-action` _(a.k.a, `v1.1.0`)_, which would cause "ELF not found" related errors.
> Ref: https://github.com/JohnnyMorganz/stylua-action/releases/tag/v1.1.1