### PR TITLE
Support custom winbar filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ symbol_in_winbar = {
     enable = false,
     separator = ' ',
     show_file = true,
+    -- define how to customize filename, eg: %:., %
+    -- if not set, use default value `%:t`
+    -- more information see `vim.fn.expand` or `expand`
+    -- ## only valid after set `show_file = true`
+    file_formatter = "",
     click_support = false,
 },
 -- show outline

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -10,8 +10,8 @@ local winbar_sep = '%#LspSagaWinbarSep#' .. config.separator .. '%*'
 local method = 'textDocument/documentSymbol'
 local cap = 'documentSymbolProvider'
 
-function symbar:get_file_name()
-  local file_name = string.gsub(vim.fn.expand('%:t'), '%%', '')
+function symbar:get_file_name(file_formatter)
+  local file_name = string.gsub(vim.fn.expand(file_formatter or '%:t'), '%%', '')
   local ok, devicons = pcall(require, 'nvim-web-devicons')
   local f_icon = ''
   local f_hl = ''
@@ -146,7 +146,7 @@ local render_symbol_winbar = function()
   local current_buf = api.nvim_get_current_buf()
   local current_line = api.nvim_win_get_cursor(current_win)[1]
 
-  local winbar_val = config.show_file and not config.in_custom and symbar:get_file_name() or ''
+  local winbar_val = config.show_file and not config.in_custom and symbar:get_file_name(config.file_formatter) or ''
 
   if not symbar.symbol_cache[current_buf] and next(symbar.symbol_cache) == nil then
     return

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -123,9 +123,9 @@ local function find_in_node(tbl, line, elements)
     for i = 1, mid - 1 do
       local prev_range = get_node_range(tbl[i]) or {}
       if -- not sure there should be 6 or other kind can be used in here
-      tbl[i].kind == 6
-          and range.start.line > prev_range.start.line
-          and range['end'].line <= prev_range['end'].line
+        tbl[i].kind == 6
+        and range.start.line > prev_range.start.line
+        and range['end'].line <= prev_range['end'].line
       then
         insert_elements(tbl[i], click, elements)
       end
@@ -145,7 +145,10 @@ local render_symbol_winbar = function()
   local current_buf = api.nvim_get_current_buf()
   local current_line = api.nvim_win_get_cursor(current_win)[1]
 
-  local winbar_val = config.show_file and not config.in_custom and symbar:get_file_name(config.file_formatter) or ''
+  local winbar_val = config.show_file
+      and not config.in_custom
+      and symbar:get_file_name(config.file_formatter)
+    or ''
 
   if not symbar.symbol_cache[current_buf] and next(symbar.symbol_cache) == nil then
     return
@@ -246,7 +249,7 @@ function symbar:symbol_events(opt)
   self:get_buf_symbol(render_symbol_winbar)
 
   local symbol_group =
-  api.nvim_create_augroup('LspsagaSymbol' .. tostring(current_buf), { clear = true })
+    api.nvim_create_augroup('LspsagaSymbol' .. tostring(current_buf), { clear = true })
   symbol_buf_ids[current_buf] = symbol_group
 
   api.nvim_create_autocmd('CursorMoved', {

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -110,11 +110,11 @@ local function find_in_node(tbl, line, elements)
   if config.click_support then
     click_node_cnt = click_node_cnt + 1
     click_node[click_node_cnt] = node
-      if type(config.click_support) == "function" then
-        click = '%' .. tostring(click_node_cnt) .. '@v:lua.___lspsaga_winbar_click@'
-      else
-        vim.notify("[LspSaga] symbol_in_winbar.click_support is not a function", vim.log.levels.WARN)
-      end
+    if type(config.click_support) == 'function' then
+      click = '%' .. tostring(click_node_cnt) .. '@v:lua.___lspsaga_winbar_click@'
+    else
+      vim.notify('[LspSaga] symbol_in_winbar.click_support is not a function', vim.log.levels.WARN)
+    end
   end
 
   local range = get_node_range(tbl[mid]) or {}
@@ -122,11 +122,10 @@ local function find_in_node(tbl, line, elements)
   if mid > 1 then
     for i = 1, mid - 1 do
       local prev_range = get_node_range(tbl[i]) or {}
-      if
-        -- not sure there should be 6 or other kind can be used in here
-        tbl[i].kind == 6
-        and range.start.line > prev_range.start.line
-        and range['end'].line <= prev_range['end'].line
+      if -- not sure there should be 6 or other kind can be used in here
+      tbl[i].kind == 6
+          and range.start.line > prev_range.start.line
+          and range['end'].line <= prev_range['end'].line
       then
         insert_elements(tbl[i], click, elements)
       end
@@ -247,7 +246,7 @@ function symbar:symbol_events(opt)
   self:get_buf_symbol(render_symbol_winbar)
 
   local symbol_group =
-    api.nvim_create_augroup('LspsagaSymbol' .. tostring(current_buf), { clear = true })
+  api.nvim_create_augroup('LspsagaSymbol' .. tostring(current_buf), { clear = true })
   symbol_buf_ids[current_buf] = symbol_group
 
   api.nvim_create_autocmd('CursorMoved', {


### PR DESCRIPTION
It's convenient to custom winbar filename with custom file formatter.
When set file_formatter to `%:.`, it will expand to:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/8556349/192696150-817963b5-f893-4f33-ad72-263fecfa3997.png">
