### PR TITLE
fix(definition): fix preview windows going back issue

### DIFF
--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -319,8 +319,7 @@ function def:focus_last_window()
   local last_window
   local curr_win = api.nvim_get_current_win()
   self:process_all_scopes(function(_, scope)
-    local valid_win = scope.winid ~= curr_win
-      and api.nvim_win_is_valid(scope.winid)
+    local valid_win = scope.winid ~= curr_win and api.nvim_win_is_valid(scope.winid)
 
     if last_window == nil or (scope.winid > last_window and valid_win) then
       last_window = scope.winid


### PR DESCRIPTION
## Overview
Since the `focus_last_window` function was placed above the `close_window` function call at https://github.com/glepnir/lspsaga.nvim/commit/580c04f13413b6d23a2defe1320afaf521079d45, the `last_window` is now not the correct window to focus.

## Before

https://user-images.githubusercontent.com/12182069/194703469-32f11088-298b-49ea-b0fd-69f9403a4c82.mov

## After

https://user-images.githubusercontent.com/12182069/194703480-e85da2a1-d707-4cf5-8291-657a71d4db88.mov

