### PR TITLE
Only append entry source and code where available

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -50,14 +50,21 @@ function diag:render_diagnostic_window(entry, option)
   local max_width = window.get_max_float_width()
 
   local header = jump_diagnostic_header(entry)
+  local source = ' '
+
   -- remove dot in source tail {lua-language-server}
   if entry.source and entry.source:find('%.$') then
     entry.source = entry.source:gsub('%.', '')
   end
-  local source = ' ' .. entry.source
+
+  if entry.source then
+    source = source .. entry.source
+  end
+
   if entry.code ~= nil then
     source = source .. '(' .. entry.code .. ')'
   end
+
   local header_with_type = header .. diag_type[entry.severity]
   local lnum_col = ' in ' .. '❮' .. entry.lnum + 1 .. ':' .. entry.col + 1 .. '❯'
   local lhs = self:code_action_map()


### PR DESCRIPTION
Before this commit, if the entry source was missing then the diagnostic view would fail with:

```
Error executing Lua callback: ...are/nvim/plugged/lspsaga.nvim/lua/lspsaga/diagnostic.lua:57: attempt to concatenate field 'source' (a nil value) stack traceback:
        ...are/nvim/plugged/lspsaga.nvim/lua/lspsaga/diagnostic.lua:57: in function 'render_diagnostic_window'
        ...are/nvim/plugged/lspsaga.nvim/lua/lspsaga/diagnostic.lua:226: in function 'move_cursor'
        ...are/nvim/plugged/lspsaga.nvim/lua/lspsaga/diagnostic.lua:234: in function <...are/nvim/plugged/lspsaga.nvim/lua/lspsaga/diagnostic.lua:229>
        .../share/nvim/plugged/lspsaga.nvim/lua/lspsaga/command.lua:56: in function 'load_command'
        ...local/share/nvim/plugged/lspsaga.nvim/plugin/lspsaga.lua:83: in function <...local/share/nvim/plugged/lspsaga.nvim/plugin/lspsaga.lua:82>
```