### PR TITLE
fix: Allow multiple keys for finder_action_keys mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,15 @@ finder_icons = {
 -- you may need to increase this value
 finder_request_timeout = 1500,
 finder_action_keys = {
-    open = "o",
-    vsplit = "s",
-    split = "i",
-    tabe = "t",
-    quit = "q",
+    open = {'o', '<CR>'},
+    vsplit = 's',
+    split = 'i',
+    tabe = 't',
+    quit = {'q', '<ESC>'},
 },
 code_action_keys = {
-    quit = "q",
-    exec = "<CR>",
+    quit = 'q',
+    exec = '<CR>',
 },
 definition_action_keys = {
   edit = '<C-c>o',
@@ -177,7 +177,7 @@ definition_action_keys = {
   tabe = '<C-c>t',
   quit = 'q',
 },
-rename_action_quit = "<C-c>",
+rename_action_quit = '<C-c>',
 rename_in_select = true,
 -- show symbols in winbar must nightly
 -- in_custom mean use lspsaga api to get symbols
@@ -351,7 +351,7 @@ custom_kind = {
 ```
 
 ### Highlight Group
-  
+
 Colors can be simply changed by overwriting the default highlights groups LspSaga is using.
 
 

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -513,23 +513,10 @@ function Finder:apply_float_map()
     { 'n', action.vsplit, vsplit_func, opts },
     { 'n', action.split, split_func, opts },
     { 'n', action.tabe, tabe_func, opts },
+    { 'n', action.open, open_func, opts },
+    { 'n', action.quit, quit_func, opts },
   }
 
-  if type(action.open) == 'table' then
-    for _, key in ipairs(action.open) do
-      insert(keymaps, { 'n', key, open_func, opts })
-    end
-  elseif type(action.open) == 'string' then
-    insert(keymaps, { 'n', action.open, open_func, opts })
-  end
-
-  if type(action.quit) == 'table' then
-    for _, key in ipairs(action.quit) do
-      insert(keymaps, { 'n', key, quit_func, opts })
-    end
-  elseif type(action.quit) == 'string' then
-    insert(keymaps, { 'n', action.quit, quit_func, opts })
-  end
   nvim_create_keymap(keymaps)
 end
 

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -41,11 +41,11 @@ saga.config_values = {
   },
   finder_request_timeout = 1500,
   finder_action_keys = {
-    open = 'o',
+    open = { 'o', '<CR>' },
     vsplit = 's',
     split = 'i',
     tabe = 't',
-    quit = 'q',
+    quit = { 'q', '<ESC>' },
   },
   code_action_keys = {
     quit = 'q',

--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -44,7 +44,15 @@ end
 
 function libs.nvim_create_keymap(definitions)
   for _, def in pairs(definitions) do
-    vim.keymap.set(def[1], def[2], def[3], def[4])
+    local mode, lhs, rhs, opts = def[1], def[2], def[3], def[4]
+
+    if type(lhs) == 'table' then
+      for _, key in ipairs(lhs) do
+        vim.keymap.set(mode, key, rhs, opts)
+      end
+    else
+      vim.keymap.set(mode, lhs, rhs, opts)
+    end
   end
 end
 


### PR DESCRIPTION
finder_action_keys mappings including 'vsplit', 'split', and 'tabe', etc.
should support multiple key choices as 'open' and 'quit' already do.

In addition, we add sensible default keys <CR> and <ESC> as default
keymappings to 'open' and 'quit' actions, respectively.
