### PR TITLE
FIX: no match highlight word, because trim of lsp

### DIFF
--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -702,11 +702,19 @@ function Finder:auto_open_preview()
       if not self.preview_hl_ns then
         self.preview_hl_ns = api.nvim_create_namespace('FinderPreview')
       end
+      local trimLines = 0
+      for _, v in pairs(content) do
+        if v == '' then
+          trimLines = trimLines + 1
+        else
+          break
+        end
+      end
       api.nvim_buf_add_highlight(
         self.preview_bufnr,
         self.preview_hl_ns,
         'FinderPreviewSearch',
-        0 + config.preview_lines_above,
+        0 + config.preview_lines_above - trimLines,
         start_pos - 1,
         _end_col
       )


### PR DESCRIPTION
When first line is empty at -preview_lines_above, `nvim_buf_add_highlight` don't works because of `vim.lsp.util._trim` 

example) preview_lines_above = 3, find symbol: DIRE

actual lines
```
(empty line)
haha
DIRE
```

preview window
```
haha
DIRE
```

