### PR TITLE
fix: outline quit issue

### DIFF
--- a/lua/lspsaga/outline.lua
+++ b/lua/lspsaga/outline.lua
@@ -144,7 +144,7 @@ function ot:auto_preview(bufnr)
   }
 
   local winid = fn.bufwinid(bufnr)
-  local _height = api.nvim_win_get_height(winid)
+  local _height = fn.winheight(winid)
   local win_height = api.nvim_win_get_height(0)
 
   if outline_conf.win_position == 'right' then


### PR DESCRIPTION
When open lspsaga outline, quit current window cause error.

Error executing vim.schedule lua callback: ...ite/pack/packer/opt/lspsaga.nvim/lua/lspsaga/outline.lua:147: Invalid window id: -1
stack traceback:
        [C]: in function 'nvim_win_get_height'
        ...ite/pack/packer/opt/lspsaga.nvim/lua/lspsaga/outline.lua:147: in function 'auto_preview'
        ...ite/pack/packer/opt/lspsaga.nvim/lua/lspsaga/outline.lua:343: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>

