### PR TITLE
Fix outline folded text

### DIFF
--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -79,6 +79,7 @@ saga.config_values = {
     virt_text = '┃',
     jump_key = 'o',
     auto_refresh = true,
+    fold_prefix = '',
   },
   custom_kind = {},
   server_filetype_map = {},


### PR DESCRIPTION
In function set_foldtext(), the foldtext is a concatenation of:
'outline_conf.fold_prefix' and the line at foldstart.
By default, fold_prefix is undefined and an empty string is returned.
This change defines fold_prefix in the default config.
