### PR TITLE
fix goto_definition remaining typo

### DIFF
--- a/lua/lspsaga/command.lua
+++ b/lua/lspsaga/command.lua
@@ -8,7 +8,7 @@ local subcommands = {
     require('lspsaga.definition'):peek_definition()
   end,
   goto_definition = function()
-    require('lspsaga.definition'):goto_defintion()
+    require('lspsaga.definition'):goto_definition()
   end,
   rename = function()
     require('lspsaga.rename'):lsp_rename()


### PR DESCRIPTION
Hi there 👋 

5ff2bc5935 fixed a typo made on the `goto_definition` function call but there is still _another_ typo when requiring the function causing the following error:

```
Error executing Lua callback: ...e/pack/packer/start/lspsaga.nvim/lua/lspsaga/command.lua:11: attempt to call method 'goto_defintion' (a nil value)
stack traceback:
        ...e/pack/packer/start/lspsaga.nvim/lua/lspsaga/command.lua:11: in function <...e/pack/packer/start/lspsaga.nvim/lua/lspsaga/command.lua:10>
        ...e/pack/packer/start/lspsaga.nvim/lua/lspsaga/command.lua:60: in function 'load_command'
        ...m/site/pack/packer/start/lspsaga.nvim/plugin/lspsaga.lua:8: in function <...m/site/pack/packer/start/lspsaga.nvim/plugin/lspsaga.lua:7>
```

This small commit addresses that issue 😊 