### PR TITLE
Fix hover_doc failure

### DIFF
--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -103,6 +103,13 @@ function hover:do_request(arg)
       return
     end
 
+    if type(result.contents) == 'string' then
+      result.contents = {
+        kind = 'markdown',
+        value = result.contents,
+      }
+    end
+
     if not result or not result.contents or next(result.contents) == nil then
       if not arg or arg ~= '++quiet' then
         vim.notify('No information available')


### PR DESCRIPTION
Some LSP servers return `textDocument/hover` contents as a markdown string (e.g. typescript-language-server)
Therefore, if the contents is a string, modify it to the appropriate type.
