### PR TITLE
Escape more characters

### DIFF
--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -26,8 +26,14 @@ function hover:open_floating_preview(res, opts)
 
   local new = {}
   for _, line in pairs(content) do
-    if line:find('&nbsp') then
-      line = line:gsub('&nbsp', ' ')
+    if line:find('&nbsp;') then
+      line = line:gsub('&nbsp;', ' ')
+    end
+    if line:find('&lt;') then
+      line = line:gsub('&lt;', '<')
+    end
+    if line:find('&gt;') then
+      line = line:gsub('&gt;', '>')
     end
     if line:find('<pre>') then
       line = line:gsub('<pre>', '```')


### PR DESCRIPTION
[This commit](https://github.com/glepnir/lspsaga.nvim/commit/80980b627918b1d85e465d65a9419fa01b8decc0) changes `&nbsp;` to whitespace but didn't clear the ending `;`, so clear it as well

Additionally, substitute/escape `&lt;` and `&gt;` 

[Example file](https://github.com/ultrafunkamsterdam/undetected-chromedriver/blob/master/undetected_chromedriver/__init__.py), pressing hover on this file is currently showing `<` as `&lt;`