### PR TITLE
fix the bug of losing index in diagnostic

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -461,7 +461,7 @@ function diag:show(entrys, arg, type)
     local code_source =
       api.nvim_buf_get_text(entry.bufnr, entry.lnum, start_col, entry.lnum, end_col, {})
     insert(len, #code_source[1])
-    local line = '['
+    local line = '  ['
       .. index
       .. '] '
       .. code_source[1]


### PR DESCRIPTION
The index of diagnostic window will be dropped since the extmark overlap it.
The extmark will take up 2  char positions, so I set 2 spaces before the index to solve it.