### PR TITLE
Fix the error when `respect_root = true`

### DIFF
--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -38,7 +38,7 @@ end
 local function bar_file_name(buf)
   local res
   if config.respect_root then
-    res = respect_lsp_root()
+    res = respect_lsp_root(buf)
   end
 
   --fallback to config.folder_level


### PR DESCRIPTION
When `respect_root = true`, there will be an error due to wrong type of parameter.