### PR TITLE
docs: correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ keymap({"n","v"}, "<leader>ca", "<cmd>Lspsaga code_action<CR>")
 keymap("n", "gr", "<cmd>Lspsaga rename<CR>")
 
 -- Peek Definition
--- you can edit the definition file in this flaotwindow
+-- you can edit the definition file in this float window
 -- also support open/vsplit/etc operation check definition_action_keys
 -- support tagstack C-t jump back
 keymap("n", "gd", "<cmd>Lspsaga peek_definition<CR>")


### PR DESCRIPTION
There is a typo in the `README.md`: "flaotwindow" instead of "float window"