### PR TITLE
docs(README): typo in the lazy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ require('lazy').setup({
     config = function()
         require('lspsaga').setup({})
     end,
-    dependices = { {'nvim-tree/nvim-web-devicons'} }
+    dependencies = { {'nvim-tree/nvim-web-devicons'} }
 },opt)
 ```
 


### PR DESCRIPTION
Fix typo with an error in the install section for lazy package manager