### PR TITLE
use cwd when lsp client no root_dir

### DIFF
--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -28,11 +28,14 @@ local function respect_lsp_root(buf)
   if #clients == 0 then
     return
   end
-  local root_dir = clients[1].config.root_dir
+  local root_dir = clients[1].config.root_dir or vim.fn.getcwd()
   local parts = vim.split(root_dir, libs.path_sep, { trimempty = true })
   local bufname = api.nvim_buf_get_name(buf)
   local bufname_parts = vim.split(bufname, libs.path_sep, { trimempty = true })
-  return { unpack(bufname_parts, #parts + 1) }
+  if bufname:find(root_dir) == 1 then
+    return { unpack(bufname_parts, #parts + 1) }
+  end
+  return { unpack(bufname_parts) }
 end
 
 local function bar_file_name(buf)


### PR DESCRIPTION
If `lsp` started in single file mode, there is no `root_dir`, for example: when edit single config file like `alacritty.yaml` with `yamlls` started.

So treat `cwd` as `root_dir` if `bufname` has prefix `root_dir` would be more suitable. Otherwise use absolute path as filename.