### PR TITLE
fix floats opens folded

### DIFF
--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -60,6 +60,7 @@ function act:action_callback()
   self.action_bufnr, self.action_winid = window.create_win_with_border(content_opts, opt)
   vim.wo[self.action_winid].conceallevel = 2
   vim.wo[self.action_winid].concealcursor = 'niv'
+  vim.wo[self.winid].foldlevel = 6
   -- initial position in code action window
   api.nvim_win_set_cursor(self.action_winid, { 1, 1 })
 

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -238,6 +238,7 @@ function diag:render_diagnostic_window(entry, option)
   vim.wo[self.winid].showbreak = 'NONE'
   vim.wo[self.winid].breakindent = true
   vim.wo[self.winid].breakindentopt = 'shift:2'
+  vim.wo[self.winid].foldlevel = 6
 
   local win_config = api.nvim_win_get_config(self.winid)
 

--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -84,6 +84,7 @@ function hover:open_floating_preview(res, option_fn)
   vim.wo[self.preview_winid].conceallevel = 2
   vim.wo[self.preview_winid].concealcursor = 'niv'
   vim.wo[self.preview_winid].showbreak = 'NONE'
+  vim.wo[self.winid].foldlevel = 6
   if fn.has('nvim-0.9') == 1 then
     vim.wo[self.preview_winid].fcs = 'lastline: '
     vim.treesitter.start(self.preview_bufnr, 'markdown')


### PR DESCRIPTION
This PR sets the `foldlevel` to the highest fold number of markdown fold headings when creating a floating window.

This should fix an interference when e.g., using https://github.com/preservim/vim-markdown with heading auto folding enabled.

Experienced issue: In my case, I have set headings above level 4 to auto-fold. Normally this should not trigger folding of content for lspsaga, but still floating windows of lspsaga were opened with folded content.

<img width=300 src="https://user-images.githubusercontent.com/34311583/215285733-bb44a311-da48-481c-9483-e06f7b34579f.png">
<img width=300 src="https://user-images.githubusercontent.com/34311583/215285731-f5be5a0d-fbd0-4c1f-ba9e-fdad509d318f.png">

Besides the mentioned plugin it will in general prevent content being opened folded in sagas floating windows.

It was already fixed once before the lspsaga 2.3 refactor in #26 . But setting the `foldlevel` when creating the window got lost along the way. 