### PR TITLE
breaking change: finder and outline

### DIFF
--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -334,7 +334,7 @@ function finder:render_finder_result()
     width = window.get_max_content_length(self.contents),
   }
 
-  local max_height = vim.o.lines * 0.5
+  local max_height = math.floor(vim.o.lines * 0.5)
   opt.height = #self.contents > max_height and max_height or #self.contents
   if opt.height <= 0 or not opt.height then
     opt.height = max_height

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -334,7 +334,7 @@ function finder:render_finder_result()
     width = window.get_max_content_length(self.contents),
   }
 
-  local max_height = math.floor(vim.o.lines * 0.5)
+  local max_height = math.floor(vim.o.lines * config.finder.max_height)
   opt.height = #self.contents > max_height and max_height or #self.contents
   if opt.height <= 0 or not opt.height then
     opt.height = max_height
@@ -504,7 +504,7 @@ function finder:apply_map()
     nowait = true,
   }
 
-  for action, map in pairs(config.finder) do
+  for action, map in pairs(config.finder.keys) do
     if type(map) == 'string' then
       map = { map }
     end
@@ -517,7 +517,7 @@ function finder:apply_map()
     end
   end
 
-  for _, key in pairs(config.finder.quit) do
+  for _, key in pairs(config.finder.keys.quit) do
     vim.keymap.set('n', key, function()
       window.nvim_close_valid_window({ self.winid, self.preview_winid })
     end, opts)

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -55,12 +55,15 @@ local default_config = {
   },
   request_timeout = 2000,
   finder = {
+    max_height = 0.5,
+    keys = {
     jump_to = 'p',
     edit = { 'o', '<CR>' },
     vsplit = 's',
     split = 'i',
     tabe = 't',
     quit = { 'q', '<ESC>' },
+    }
   },
   definition = {
     edit = '<C-c>o',
@@ -95,6 +98,7 @@ local default_config = {
     auto_refresh = true,
     auto_close = true,
     custom_sort = nil,
+    focus = true,
     keys = {
       jump = 'o',
       expand_collapse = 'u',

--- a/lua/lspsaga/outline.lua
+++ b/lua/lspsaga/outline.lua
@@ -323,6 +323,9 @@ function ot:auto_refresh()
     end,
     desc = '[Lspsaga.nvim] outline auto refresh',
   })
+  if not config.outline.focus then
+      vim.cmd("wincmd p")
+  end
 end
 
 function ot:auto_preview()


### PR DESCRIPTION
This PR has two contributors,
1. (breaking change) Add handler to control the height of finder. This update change finder's config table, move key binding to a new key table like other sections.
2. Add config to control enter outline with/without focus.