### PR TITLE
version 2.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,16 +180,21 @@ A `finder` to show the defintion, reference and implementation (only shown when 
 Default options:
 ```lua
   finder = {
-    jump_to = 'p',
-    edit = { "o", "<CR>" },
-    vsplit = "s",
-    split = "i",
-    tabe = "t",
-    quit = { "q", "<ESC>" },
+    --percentage
+    max_height = 0.5,
+    keys = {
+      jump_to = 'p',
+      edit = { 'o', '<CR>' },
+      vsplit = 's',
+      split = 'i',
+      tabe = 't',
+      quit = { 'q', '<ESC>' },
+    },
   },
 ```
 
-- `jump_to` finder peek window.
+- `max_height` of the finder window.
+- `keys.jump_to` finder peek window.
 
 <details>
 <summary>lsp_finder showcase</summary>
@@ -311,6 +316,7 @@ Default options:
     custom_fix = nil,
     custom_msg = nil,
     text_hl_follow = false,
+    border_follow = true,
     keys = {
       exec_action = "o",
       quit = "q",
@@ -326,6 +332,8 @@ Default options:
 - `max_width` is the max width for diagnostic jump window. percentage
 - `text_hl_follow` is false default true that you can define `DiagnostcText` to custom the diagnotic
   text color
+- `border_follow` the border highlight will follow the diagnostic type. if false it will use the
+  highlight `DiagnosticBorder`.
 
 You can also use a filter when using diagnostic jump by using a Lspsaga function. The function takes a table as its argument.
 It is functionally identical to `:h vim.diagnostic.get_next`.

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -227,6 +227,11 @@ function def:apply_aciton_keys(pos)
         return
       end
 
+      local curbuf = api.nvim_get_current_buf()
+      if #fn.win_findbuf(curbuf) == 1 then
+        api.nvim_set_option_value('bufhidden', 'wipe', { buf = curbuf })
+      end
+
       api.nvim_win_close(curwin, true)
       local node = ctx.data[index]
       vim.cmd(action .. ' ' .. node.link)

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -202,16 +202,6 @@ function def:event(bufnr)
       remove(node)
     end,
   })
-
-  api.nvim_create_autocmd('WinClosed', {
-    buffer = bufnr,
-    callback = function()
-      local cur = api.nvim_get_current_win()
-      if stack_cap() == 1 and ctx.data[1].winid == cur then
-        clean_ctx()
-      end
-    end,
-  })
 end
 
 local function unpack_maps()
@@ -237,6 +227,7 @@ function def:apply_aciton_keys(pos)
         return
       end
 
+      api.nvim_win_close(curwin, true)
       local node = ctx.data[index]
       vim.cmd(action .. ' ' .. node.link)
       api.nvim_win_set_cursor(0, { pos[1] + 1, pos[2] })

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -196,7 +196,7 @@ function diag:render_diagnostic_window(entry, option)
     buftype = 'nofile',
     wrap = true,
     highlight = {
-      border = hi_name,
+      border = diag_conf.border_follow and hi_name or 'DiagnosticBorder',
       normal = 'DiagnosticNormal',
     },
   }

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -218,7 +218,6 @@ function diag:render_diagnostic_window(entry, option)
     height = #content + increase,
     no_size_override = true,
     focusable = true,
-    noautocmd = true,
   }
 
   local color = get_colors(hi_name)
@@ -529,7 +528,6 @@ function diag:show(entrys, arg, type)
     width = max_len + 10 < max_width and max_len + 5 or max_width,
     height = #content * 2 + increase,
     no_size_override = true,
-    noautocmd = true,
   }
 
   if arg and arg == '++unfocus' then

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -633,43 +633,37 @@ function finder:auto_open_preview()
     end
   end
 
-  vim.defer_fn(function()
-    -- opts.noautocmd = true
-    self.preview_bufnr, self.preview_winid = window.create_win_with_border(content_opts, opts)
-    if not data.content then
-      vim.bo[self.preview_bufnr].filetype = vim.bo[self.main_buf].filetype
-    end
+  self.preview_bufnr, self.preview_winid = window.create_win_with_border(content_opts, opts)
 
-    self.wipe_buffers = {}
+  self.wipe_buffers = {}
 
-    if #fn.win_findbuf(data.bufnr) == 1 then
-      api.nvim_buf_call(data.bufnr, function()
-        pcall(vim.cmd, 'TSBufEnable highlight')
-      end)
-      table.insert(self.wipe_buffers, data.bufnr)
-    end
+  if #fn.win_findbuf(data.bufnr) == 1 then
+    api.nvim_buf_call(data.bufnr, function()
+      pcall(vim.cmd, 'TSBufEnable highlight')
+    end)
+    table.insert(self.wipe_buffers, data.bufnr)
+  end
 
-    if data.row then
-      api.nvim_win_set_cursor(self.preview_winid, { data.row + 1, data.col })
-    end
+  if data.row then
+    api.nvim_win_set_cursor(self.preview_winid, { data.row + 1, data.col })
+  end
 
-    libs.scroll_in_preview(self.bufnr, self.preview_winid)
+  libs.scroll_in_preview(self.bufnr, self.preview_winid)
 
-    if not self.preview_hl_ns then
-      self.preview_hl_ns = api.nvim_create_namespace('finderPreview')
-    end
+  if not self.preview_hl_ns then
+    self.preview_hl_ns = api.nvim_create_namespace('finderPreview')
+  end
 
-    if data.row then
-      api.nvim_buf_add_highlight(
-        self.preview_bufnr,
-        self.preview_hl_ns,
-        'finderPreviewSearch',
-        data.row,
-        data.col,
-        data._end_col
-      )
-    end
-  end, 10)
+  if data.row then
+    api.nvim_buf_add_highlight(
+      self.preview_bufnr,
+      self.preview_hl_ns,
+      'finderPreviewSearch',
+      data.row,
+      data.col,
+      data._end_col
+    )
+  end
 end
 
 function finder:close_auto_preview_win()

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -529,8 +529,9 @@ function finder:apply_map()
 
   for _, key in pairs(config.finder.keys.quit) do
     vim.keymap.set('n', key, function()
-      pcall(api.nvim_buf_clear_namespace, self.preview_bufnr, self.preview_hl_ns, 0, -1)
-      self:quit_with_clear()
+      self:quit_float_window()
+      self:clean_data()
+      self:clean_ctx()
     end, opts)
   end
 
@@ -743,11 +744,6 @@ function finder:clean_ctx()
   for k, _ in pairs(ctx) do
     ctx[k] = nil
   end
-end
-
-function finder:quit_with_clear()
-  self:quit_float_window()
-  self:clear_ctx()
 end
 
 return setmetatable(ctx, finder)

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -167,8 +167,10 @@ function finder:do_request(params, method)
   lsp.buf_request_all(self.current_buf, method, params, function(results)
     local result = {}
     for _, res in pairs(results or {}) do
-      if res.result then
+      if res.result and not (res.result.uri or res.result.targetUri) then
         libs.merge_table(result, res.result)
+      elseif res.result and (res.result.uri or res.result.targetUri) then
+        table.insert(result, res.result)
       end
     end
 

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -287,7 +287,9 @@ function finder:create_finder_contents(result, method)
     local path_sep = libs.path_sep
     -- reduce filename length by root_dir or home dir
     if root_dir and link:find(root_dir, 1, true) then
-      short_name = link:sub(root_dir:len() + #libs.path_sep)
+      local root_parts = vim.split(root_dir, libs.path_sep, { trimempty = true })
+      local link_parts = vim.split(link, libs.path_sep, { trimempty = true })
+      short_name = table.concat({ unpack(link_parts, #root_parts + 1) }, libs.path_sep)
     else
       local _split = vim.split(link, path_sep)
       if #_split >= 4 then

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -374,6 +374,15 @@ function finder:render_finder_result()
   self.bufnr, self.winid = window.create_win_with_border(content_opts, opt)
   api.nvim_win_set_option(self.winid, 'cursorline', false)
 
+  -- make sure close preview window by using wincmd
+  api.nvim_create_autocmd('WinClosed', {
+    buffer = self.bufnr,
+    once = true,
+    callback = function()
+      self:close_auto_preview_win()
+    end,
+  })
+
   self:set_cursor()
 
   api.nvim_create_autocmd('CursorMoved', {

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -32,16 +32,14 @@ local function methods(index)
 end
 
 local function supports_implement(buf)
-  local support = {}
+  local support = false
   for _, client in pairs(lsp.get_active_clients({ bufnr = buf })) do
-    if not client.supports_method(methods(2)) then
-      table.insert(support, false)
+    if client.supports_method('textDocument/implementation') then
+      support = true
+      break
     end
   end
-  if vim.tbl_contains(support, false) then
-    return false
-  end
-  return true
+  return support
 end
 
 function finder:lsp_finder()
@@ -259,8 +257,8 @@ function finder:create_finder_contents(result, method)
     insert(contents, { self.indent .. self.f_icon .. get_msg(method), false })
     insert(contents, { ' ', false })
     self.short_link[#contents - 1] = {
-      preview = { 'Sorry not result found' },
-      link = api.nvim_buf_get_name(self.main_buf),
+      content = { 'Sorry does not any Definition Found' },
+      link = api.nvim_buf_get_name(0),
     }
     return contents
   end
@@ -298,24 +296,16 @@ function finder:create_finder_contents(result, method)
     local target_line = self.indent .. self.f_icon .. short_name
 
     local range = res.targetRange or res.range
-    local lines = api.nvim_buf_get_lines(
-      bufnr,
-      range.start.line - config.preview.lines_above,
-      range['end'].line + 1 + config.preview.lines_below,
-      false
-    )
 
     local link_with_preview = {
+      bufnr = bufnr,
       link = link,
-      preview = lines,
-      row = range.start.line + 1,
-      col = range.start.character + 1,
+      row = range.start.line,
+      col = range.start.character,
       _end_col = range['end'].character,
     }
+
     insert(contents, { target_line, link_with_preview })
-    if bufnr ~= self.main_buf then
-      api.nvim_buf_delete(bufnr, { force = true })
-    end
   end
   insert(contents, { ' ', false })
   return contents
@@ -383,26 +373,6 @@ function finder:render_finder_result()
     callback = function()
       self:set_cursor()
       self:auto_open_preview()
-    end,
-  })
-
-  local events = { 'WinClosed', 'WinLeave' }
-
-  api.nvim_create_autocmd(events, {
-    group = finder_group,
-    buffer = self.bufnr,
-    callback = function()
-      self:quit_with_clear()
-      if finder_group then
-        pcall(api.nvim_del_augroup_by_id, finder_group)
-      end
-      -- make sure close all finder preview window
-      for _, win in pairs(api.nvim_list_wins()) do
-        local ok, id = pcall(api.nvim_win_get_var, win, 'finder_preview')
-        if ok then
-          pcall(api.nvim_win_close, id, true)
-        end
-      end
     end,
   })
 
@@ -488,6 +458,18 @@ function finder:render_finder_result()
       virt_text_pos = 'overlay',
     })
   end
+
+  vim.defer_fn(function()
+    api.nvim_create_autocmd('BufLeave', {
+      buffer = self.bufnr,
+      callback = function()
+        if self.winid and api.nvim_win_is_valid(self.winid) then
+          self:quit_float_window()
+        end
+      end,
+    })
+  end, 0)
+
   -- disable some move keys in finder window
   libs.disable_move_keys(self.bufnr)
   -- load float window map
@@ -495,13 +477,24 @@ function finder:render_finder_result()
   self:lsp_finder_highlight()
 end
 
+local function unpack_map()
+  local map = {}
+  for k, v in pairs(config.finder) do
+    if k ~= 'jump_to' then
+      map[k] = v
+    end
+  end
+  return map
+end
+
 function finder:apply_map()
   local opts = {
     buffer = true,
     nowait = true,
   }
+  local unpacked = unpack_map()
 
-  for action, map in pairs(config.finder) do
+  for action, map in pairs(unpacked) do
     if type(map) == 'string' then
       map = { map }
     end
@@ -516,9 +509,16 @@ function finder:apply_map()
 
   for _, key in pairs(config.finder.quit) do
     vim.keymap.set('n', key, function()
+      pcall(api.nvim_buf_clear_namespace, self.preview_bufnr, self.preview_hl_ns, 0, -1)
       window.nvim_close_valid_window({ self.winid, self.preview_winid })
     end, opts)
   end
+
+  vim.keymap.set('n', config.finder.jump_to, function()
+    if self.preview_winid and api.nvim_win_is_valid(self.preview_winid) then
+      api.nvim_set_current_win(self.preview_winid)
+    end
+  end, opts)
 end
 
 function finder:lsp_finder_highlight()
@@ -578,115 +578,87 @@ function finder:set_cursor()
 end
 
 function finder:auto_open_preview()
-  local current_line = fn.line('.')
+  local current_line = api.nvim_win_get_cursor(0)[1]
   if not self.short_link[current_line] then
     return
   end
 
-  local content
-  local table_length = vim.tbl_count(self.short_link[current_line].preview)
+  local data = self.short_link[current_line]
 
-  if
-    table_length == 0 or (self.short_link[current_line].preview[1] == '' and table_length == 1)
-  then
-    content = { 'the file is empty' }
-  else
-    content = self.short_link[current_line].preview
+  local opts = {
+    relative = 'editor',
+    -- We'll make sure the preview window is the correct size
+    no_size_override = true,
+  }
+
+  local winconfig = api.nvim_win_get_config(self.winid)
+  opts.col = winconfig.col[false] + winconfig.width + 2
+  opts.row = winconfig.row[false]
+  opts.height = winconfig.height
+  opts.width = vim.o.columns - opts.col - 4
+
+  local rtop = window.combine_char()['righttop'][config.ui.border]
+  local rbottom = window.combine_char()['rightbottom'][config.ui.border]
+  local content_opts = {
+    contents = data.content or {},
+    bufnr = data.bufnr or nil,
+    border_side = {
+      ['lefttop'] = rtop,
+      ['leftbottom'] = rbottom,
+    },
+    highlight = {
+      border = 'finderPreviewBorder',
+      normal = 'finderNormal',
+    },
+  }
+
+  if fn.has('nvim-0.9') == 1 and config.ui.title then
+    local path = vim.split(self.short_link[current_line].link, libs.path_sep, { trimempty = true })
+    opts.title = {
+      { path[#path], 'TitleString' },
+    }
+    local icon_data = libs.icon_from_devicon(vim.bo[self.main_buf].filetype)
+    if #icon_data > 0 then
+      table.insert(opts.title, 1, { icon_data[1] .. ' ', icon_data[2] })
+    end
   end
 
-  local start_pos = self.short_link[current_line].col
-  local _end_col = self.short_link[current_line]._end_col
+  self:close_auto_preview_win()
 
-  if next(content) ~= nil then
-    local opts = {
-      relative = 'editor',
-      -- We'll make sure the preview window is the correct size
-      no_size_override = true,
-    }
-
-    local winconfig = api.nvim_win_get_config(self.winid)
-    opts.col = winconfig.col[false] + winconfig.width + 2
-    opts.row = winconfig.row[false]
-    opts.height = winconfig.height
-    local max_width = vim.o.columns - opts.col - 4
-    local max_len = window.get_max_content_length(content)
-    opts.width = max_width > max_len and max_len or max_width
-
-    local rtop = window.combine_char()['righttop'][config.ui.border]
-    local rbottom = window.combine_char()['rightbottom'][config.ui.border]
-    local content_opts = {
-      contents = content,
-      buftype = 'nofile',
-      border_side = {
-        ['lefttop'] = rtop,
-        ['leftbottom'] = rbottom,
-      },
-      highlight = {
-        border = 'finderPreviewBorder',
-        normal = 'finderNormal',
-      },
-    }
-
-    if fn.has('nvim-0.9') == 1 and config.ui.title then
-      local path =
-        vim.split(self.short_link[current_line].link, libs.path_sep, { trimempty = true })
-      opts.title = {
-        { path[#path], 'TitleString' },
-      }
-      local icon_data = libs.icon_from_devicon(vim.bo[self.main_buf].filetype)
-      if #icon_data > 0 then
-        table.insert(opts.title, 1, { icon_data[1] .. ' ', icon_data[2] })
-      end
+  vim.defer_fn(function()
+    -- opts.noautocmd = true
+    self.preview_bufnr, self.preview_winid = window.create_win_with_border(content_opts, opts)
+    vim.bo[self.preview_bufnr].filetype = vim.bo[self.main_buf].filetype
+    if data.bufnr and data.bufnr ~= self.main_buf then
+      api.nvim_buf_set_option(data.bufnr, 'buflisted', false)
     end
 
-    self:close_auto_preview_win()
+    if data.row then
+      api.nvim_win_set_cursor(self.preview_winid, { data.row + 1, data.col })
+    end
 
-    vim.defer_fn(function()
-      opts.noautocmd = true
-      self.preview_bufnr, self.preview_winid = window.create_win_with_border(content_opts, opts)
-      vim.bo[self.preview_bufnr].filetype = vim.bo[self.main_buf].filetype
-      api.nvim_buf_set_option(self.preview_bufnr, 'buflisted', false)
-      api.nvim_win_set_var(self.preview_winid, 'finder_preview', self.preview_winid)
+    libs.scroll_in_preview(self.bufnr, self.preview_winid)
 
-      libs.scroll_in_preview(self.bufnr, self.preview_winid)
+    if not self.preview_hl_ns then
+      self.preview_hl_ns = api.nvim_create_namespace('finderPreview')
+    end
 
-      if not self.preview_hl_ns then
-        self.preview_hl_ns = api.nvim_create_namespace('finderPreview')
-      end
-      local trimLines = 0
-      for _, v in pairs(content) do
-        if v == '' then
-          trimLines = trimLines + 1
-        else
-          break
-        end
-      end
-
-      if not start_pos then
-        return
-      end
-
-      if 0 + config.preview.lines_above - trimLines >= 0 then
-        api.nvim_buf_add_highlight(
-          self.preview_bufnr,
-          self.preview_hl_ns,
-          'finderPreviewSearch',
-          0 + config.preview.lines_above - trimLines,
-          start_pos - 1,
-          _end_col
-        )
-      end
-    end, 10)
-  end
+    if data.row then
+      api.nvim_buf_add_highlight(
+        self.preview_bufnr,
+        self.preview_hl_ns,
+        'finderPreviewSearch',
+        data.row,
+        data.col,
+        data._end_col
+      )
+    end
+  end, 10)
 end
 
 function finder:close_auto_preview_win()
   if self.preview_hl_ns then
     pcall(api.nvim_buf_clear_namespace, self.preview_bufnr, self.preview_hl_ns, 0, -1)
-  end
-  if self.preview_bufnr and api.nvim_buf_is_loaded(self.preview_bufnr) then
-    api.nvim_buf_delete(self.preview_bufnr, { force = true })
-    self.preview_bufnr = nil
   end
 
   if self.preview_winid and api.nvim_win_is_valid(self.preview_winid) then
@@ -711,13 +683,14 @@ function finder:open_link(action)
     vim.cmd('write')
   end
   vim.cmd(action .. ' ' .. uv.fs_realpath(short_link[current_line].link))
-  api.nvim_win_set_cursor(0, { short_link[current_line].row, short_link[current_line].col - 1 })
+  api.nvim_win_set_cursor(0, { short_link[current_line].row + 1, short_link[current_line].col })
   local width = #api.nvim_get_current_line()
-  libs.jump_beacon({ short_link[current_line].row - 1, 0 }, width)
+  libs.jump_beacon({ short_link[current_line].row, 0 }, width)
   self:clear_tmp_data()
 end
 
 function finder:quit_float_window()
+  pcall(api.nvim_buf_clear_namespace, self.preview_bufnr, self.preview_hl_ns, 0, -1)
   if self.bufnr and api.nvim_buf_is_loaded(self.bufnr) then
     api.nvim_buf_delete(self.bufnr, { force = true })
     self.bufnr = nil

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -285,7 +285,7 @@ function finder:create_finder_contents(result, method)
     local path_sep = libs.path_sep
     -- reduce filename length by root_dir or home dir
     if root_dir and link:find(root_dir, 1, true) then
-      short_name = link:sub(root_dir:len() + 2)
+      short_name = link:sub(root_dir:len() + #libs.path_sep)
     else
       local _split = vim.split(link, path_sep)
       if #_split >= 4 then

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -634,7 +634,10 @@ function finder:auto_open_preview()
   vim.defer_fn(function()
     -- opts.noautocmd = true
     self.preview_bufnr, self.preview_winid = window.create_win_with_border(content_opts, opts)
-    vim.bo[self.preview_bufnr].filetype = vim.bo[self.main_buf].filetype
+    if not data.content then
+      vim.bo[self.preview_bufnr].filetype = vim.bo[self.main_buf].filetype
+    end
+
     self.wipe_buffers = {}
 
     if #fn.win_findbuf(data.bufnr) == 1 then

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -342,9 +342,11 @@ function finder:render_finder_result()
 
   local winline = fn.winline()
   if vim.o.lines - 6 - opt.height - winline <= 0 then
-    vim.cmd('normal! zz')
-    local keycode = api.nvim_replace_termcodes('6<C-e>', true, false, true)
-    api.nvim_feedkeys(keycode, 'x', false)
+    api.nvim_win_call(self.main_win, function()
+      vim.cmd('normal! zz')
+      local keycode = api.nvim_replace_termcodes('6<C-e>', true, false, true)
+      api.nvim_feedkeys(keycode, 'x', false)
+    end)
   end
   winline = fn.winline()
   opt.row = winline + 1

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -342,7 +342,7 @@ function finder:render_finder_result()
     api.nvim_feedkeys(keycode, 'x', false)
   end
   winline = fn.winline()
-  opt.row = winline + 2
+  opt.row = winline + 1
   opt.col = 10
 
   local side_char = window.border_chars()['top'][config.ui.border]

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -479,7 +479,7 @@ end
 
 local function unpack_map()
   local map = {}
-  for k, v in pairs(config.finder) do
+  for k, v in pairs(config.finder.keys) do
     if k ~= 'jump_to' then
       map[k] = v
     end
@@ -508,14 +508,14 @@ function finder:apply_map()
     end
   end
 
-  for _, key in pairs(config.finder.quit) do
+  for _, key in pairs(config.finder.keys.quit) do
     vim.keymap.set('n', key, function()
       pcall(api.nvim_buf_clear_namespace, self.preview_bufnr, self.preview_hl_ns, 0, -1)
       window.nvim_close_valid_window({ self.winid, self.preview_winid })
     end, opts)
   end
 
-  vim.keymap.set('n', config.finder.jump_to, function()
+  vim.keymap.set('n', config.finder.keys.jump_to, function()
     if self.preview_winid and api.nvim_win_is_valid(self.preview_winid) then
       api.nvim_set_current_win(self.preview_winid)
     end
@@ -661,7 +661,6 @@ function finder:close_auto_preview_win()
     pcall(api.nvim_buf_clear_namespace, self.preview_bufnr, self.preview_hl_ns, 0, -1)
   end
 
-  print(self.preview_winid)
   if self.preview_winid and api.nvim_win_is_valid(self.preview_winid) then
     api.nvim_win_close(self.preview_winid, true)
     self.preview_winid = nil

--- a/lua/lspsaga/highlight.lua
+++ b/lua/lspsaga/highlight.lua
@@ -74,10 +74,6 @@ local function hi_define()
     DiagnosticBorder = { link = 'SagaBorder' },
     DiagnosticSource = { fg = 'gray' },
     DiagnosticNormal = { link = 'SagaNormal' },
-    DiagnosticErrorBorder = { link = 'DiagnosticError' },
-    DiagnosticWarnBorder = { link = 'DiagnosticWarn' },
-    DiagnosticHintBorder = { link = 'DiagnosticHint' },
-    DiagnosticInfoBorder = { link = 'DiagnosticInfo' },
     DiagnosticPos = { fg = colors.gray },
     DiagnosticWord = { fg = colors.fg },
     -- Call Hierachry

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -24,6 +24,7 @@ local default_config = {
     custom_fix = nil,
     custom_msg = nil,
     text_hl_follow = false,
+    border_follow = true,
     keys = {
       exec_action = 'o',
       quit = 'q',

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -55,15 +55,19 @@ local default_config = {
   },
   request_timeout = 2000,
   finder = {
-    jump_to = 'p',
-    edit = { 'o', '<CR>' },
-    vsplit = 's',
-    split = 'i',
-    tabe = 't',
-    quit = { 'q', '<ESC>' },
+    --percentage
+    max_height = 0.5,
+    keys = {
+      jump_to = 'p',
+      edit = { 'o', '<CR>' },
+      vsplit = 's',
+      split = 'i',
+      tabe = 't',
+      quit = { 'q', '<ESC>' },
+    },
   },
   definition = {
-    edit = '<CR>',
+    edit = '<C-c>o',
     vsplit = '<C-c>v',
     split = '<C-c>i',
     tabe = '<C-c>t',

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -63,7 +63,7 @@ local default_config = {
     quit = { 'q', '<ESC>' },
   },
   definition = {
-    edit = '<C-c>o',
+    edit = '<CR>',
     vsplit = '<C-c>v',
     split = '<C-c>i',
     tabe = '<C-c>t',

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -224,10 +224,10 @@ local render_symbol_winbar = function(buf, symbols)
     return
   end
 
-  --only render in first win
+  -- don't show in float window.
   local cur_win = api.nvim_get_current_win()
-  local first_win = fn.bufwinid(buf)
-  if cur_win ~= first_win then
+  local winconf = api.nvim_win_get_config(cur_win)
+  if winconf.relative then
     return
   end
 

--- a/lua/lspsaga/symbolwinbar.lua
+++ b/lua/lspsaga/symbolwinbar.lua
@@ -215,9 +215,10 @@ local render_symbol_winbar = function(buf, symbols)
     return
   end
 
-  local all_wins = fn.win_findbuf(buf)
+  --only render in first win
   local cur_win = api.nvim_get_current_win()
-  if not vim.tbl_contains(all_wins, cur_win) then
+  local first_win = fn.bufwinid(buf)
+  if cur_win ~= first_win then
     return
   end
 

--- a/plugin/lspsaga.lua
+++ b/plugin/lspsaga.lua
@@ -2,7 +2,7 @@ if vim.g.lspsaga_version then
   return
 end
 
-vim.g.lspsaga_version = '0.2.5'
+vim.g.lspsaga_version = '0.2.6'
 
 vim.api.nvim_create_user_command('Lspsaga', function(args)
   require('lspsaga.command').load_command(unpack(args.fargs))


### PR DESCRIPTION
## Finder
- Preview
now finder preview window is a normal buffer that support edit file save.  use new option `finder.keys.jump_to` to jump into it then do your edit.

- Highlight
 syntax  highlight for nvim 0.9 use treesitter render for nvim 0.8 use regex syntax highlight.  why it different. because when you are in a huge project.  the lsp request of `textDocument/definition textDocument/reference textDocument/implement`
will have lots of responses . these responses will have many file link that need convert to buffer.   when buffer load it will trigger `FileType` event. currently lspconfig use `FileType` event to attach buffer to lsp client. if the server not support 
`workspaceFolder` it will spawn many lsp server instances and more memory usage .  make finder very slow. that's too bad. so I disabled the `FileType` event.  the side effect is lose the treesitter render. in nvim-0.9 we have a new api `vim.treesitter.start` can rehighlight it.  but we don't have it in nvim0.8 so for  nvim0.8  use regex syntax highlight. 
 
- Window behavior
new window position from vscode. all the peek functions in vscode when the height is not enough  it will make the line moveup  to get more space to open the peek window. so finder now use same behavior . if the space of line below is not enough to show the finder window . it will make the line to center `normal! zz` and do 6 scroll make sure it bigger enough
to show the `finder.max_height` window height. the `finder.max_height` default is 0.5

ps: I just test these peek functions in vscode.

### BreakChanges
finder option now is changed . all the keymap need config in `finder.keys` field. new options .`finder.max_height` the max height of finder. notice finder still respect the all the content height. if it smaller than max_height it still use the height of content .

## Symbols winbar
now only show symbols winbar in first window of this buffer . this mean if buffer in many windows like floatwindow .that mean it only show in first window .

## Diagnostic
add new option `diagnostic.border_follow` default is true  then the border will follow the diagnostic type. if false it will use
the `DiagnosticBorder`.

### Chore

- definition bug fix.
- code clean
