### PR TITLE
Option to show name of the LSP in code actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Default options:
 ```lua
   code_action = {
     num_shortcut = true,
+    show_server_name = false,
     keys = {
       -- string | table type
       quit = "q",

--- a/doc/lspsaga.nvim.txt
+++ b/doc/lspsaga.nvim.txt
@@ -301,6 +301,7 @@ Default options:
 >
       code_action = {
         num_shortcut = true,
+	show_server_name = false,
         keys = {
           -- string | table type
           quit = "q",

--- a/doc/lspsaga.nvim.txt
+++ b/doc/lspsaga.nvim.txt
@@ -301,7 +301,6 @@ Default options:
 >
       code_action = {
         num_shortcut = true,
-	show_server_name = false,
         keys = {
           -- string | table type
           quit = "q",

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -22,13 +22,16 @@ function act:action_callback()
   for index, client_with_actions in pairs(self.action_tuples) do
     local action_title = ''
     local indent = index > 9 and '' or ' '
-    if #client_with_actions ~= 2 then
+    if #client_with_actions ~= 3 then
       vim.notify('There has something wrong in aciton_tuples')
       return
     end
     if client_with_actions[2].title then
       action_title = indent .. index .. '  ' .. client_with_actions[2].title
     end
+		if (config.code_action.show_server_name == true) then
+			action_title = action_title .. '  ' .. client_with_actions[3]
+		end
     table.insert(contents, action_title)
   end
 
@@ -53,7 +56,7 @@ function act:action_callback()
 
   if fn.has('nvim-0.9') == 1 and config.ui.title then
     opt.title = {
-      { config.ui.code_action .. ' CodeActions', 'TitleString' },
+      { config.ui.code_action .. 'A CodeActions', 'TitleString' },
     }
   end
 
@@ -148,8 +151,9 @@ function act:send_code_action_request(main_buf, options, cb)
     self.action_tuples = {}
 
     for client_id, result in pairs(results) do
+			local name = vim.lsp.get_client_by_id(client_id).name
       for _, action in pairs(result.result or {}) do
-        table.insert(self.action_tuples, { client_id, action })
+        table.insert(self.action_tuples, { client_id, action, name })
       end
     end
 

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -22,7 +22,7 @@ function act:action_callback()
   for index, client_with_actions in pairs(self.action_tuples) do
     local action_title = ''
     local indent = index > 9 and '' or ' '
-    if #client_with_actions ~= 3 then
+    if #client_with_actions ~= 2 then
       vim.notify('There has something wrong in aciton_tuples')
       return
     end
@@ -30,7 +30,8 @@ function act:action_callback()
       action_title = indent .. index .. '  ' .. client_with_actions[2].title
     end
 		if (config.code_action.show_server_name == true) then
-			action_title = action_title .. '  ' .. client_with_actions[3]
+			local name = vim.lsp.get_client_by_id(client_with_actions[1]).name
+			action_title = action_title .. '  ' .. name
 		end
     table.insert(contents, action_title)
   end
@@ -151,9 +152,8 @@ function act:send_code_action_request(main_buf, options, cb)
     self.action_tuples = {}
 
     for client_id, result in pairs(results) do
-			local name = vim.lsp.get_client_by_id(client_id).name
       for _, action in pairs(result.result or {}) do
-        table.insert(self.action_tuples, { client_id, action, name })
+        table.insert(self.action_tuples, { client_id, action })
       end
     end
 

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -29,10 +29,10 @@ function act:action_callback()
     if client_with_actions[2].title then
       action_title = indent .. index .. '  ' .. client_with_actions[2].title
     end
-		if (config.code_action.show_server_name == true) then
-			local name = vim.lsp.get_client_by_id(client_with_actions[1]).name
-			action_title = action_title .. '  ' .. name
-		end
+    if config.code_action.show_server_name == true then
+      local name = vim.lsp.get_client_by_id(client_with_actions[1]).name
+      action_title = action_title .. '  ' .. name
+    end
     table.insert(contents, action_title)
   end
 

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -56,7 +56,7 @@ function act:action_callback()
 
   if fn.has('nvim-0.9') == 1 and config.ui.title then
     opt.title = {
-      { config.ui.code_action .. 'A CodeActions', 'TitleString' },
+      { config.ui.code_action .. ' CodeActions', 'TitleString' },
     }
   end
 

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -33,6 +33,7 @@ local default_config = {
   },
   code_action = {
     num_shortcut = true,
+		show_server_name = false,
     keys = {
       quit = 'q',
       exec = '<CR>',

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -33,7 +33,7 @@ local default_config = {
   },
   code_action = {
     num_shortcut = true,
-		show_server_name = false,
+    show_server_name = false,
     keys = {
       quit = 'q',
       exec = '<CR>',


### PR DESCRIPTION
This is useful if you have many active LSPs. Won't be useful for everyone though which is why i've set it to be disabled by default.