### PR TITLE
Fix some grammar in messages/errors

### DIFF
--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -188,7 +188,7 @@ end
 
 function ch:send_prepare_call()
   if self.pending_request then
-    vim.notify('there already have a request please wait.')
+    vim.notify('there is already a request please wait.')
     return
   end
   self.main_buf = api.nvim_get_current_buf()

--- a/lua/lspsaga/codeaction.lua
+++ b/lua/lspsaga/codeaction.lua
@@ -23,7 +23,7 @@ function act:action_callback()
     local action_title = ''
     local indent = index > 9 and '' or ' '
     if #client_with_actions ~= 2 then
-      vim.notify('There has something wrong in aciton_tuples')
+      vim.notify('There is something wrong in aciton_tuples')
       return
     end
     if client_with_actions[2].title then
@@ -119,7 +119,7 @@ function act:send_code_action_request(main_buf, options, cb)
   if options.range then
     assert(type(options.range) == 'table', 'code_action range must be a table')
     local start = assert(options.range.start, 'range must have a `start` property')
-    local end_ = assert(options.range['end'], 'range must have a `end` property')
+    local end_ = assert(options.range['end'], 'range must have an `end` property')
     params = util.make_given_range_params(start, end_)
   elseif mode == 'v' or mode == 'V' then
     -- [bufnum, lnum, col, off]; both row and column 1-indexed
@@ -194,7 +194,7 @@ end
 function act:code_action(options)
   if self.pending_request then
     vim.notify(
-      '[lspsaga.nvim] there already have a code action request please wait',
+      '[lspsaga.nvim] there is already a code action request please wait',
       vim.log.levels.WARN
     )
     return

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -71,7 +71,7 @@ local function get_uri_data(result)
   end
 
   if not res.uri then
-    vim.notify('[Lspsaga] Does not find target uri', vim.log.levels.WARN)
+    vim.notify('[Lspsaga] Did not find target uri', vim.log.levels.WARN)
     return
   end
 

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -66,7 +66,7 @@ function diag:code_action_cb()
 
   for index, client_with_actions in pairs(act.action_tuples) do
     if #client_with_actions ~= 2 then
-      vim.notify('There has something wrong in aciton_tuples')
+      vim.notify('There is something wrong in aciton_tuples')
       return
     end
     if client_with_actions[2].title then

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -242,7 +242,7 @@ local function get_msg(method)
   local idx = libs.tbl_index(methods(), method)
   local t = {
     'No Definition Found',
-    'No Implement  Found',
+    'No Implementation  Found',
     'No Reference  Found',
   }
   return t[idx]
@@ -259,7 +259,7 @@ function finder:create_finder_contents(result, method)
     insert(contents, { '    ' .. icon_data[1] .. get_msg(method), false })
     insert(contents, { ' ', false })
     self.short_link[#contents - 1] = {
-      content = { 'Sorry does not any Definition Found' },
+      content = { 'Sorry did not find any Definition' },
       link = api.nvim_buf_get_name(0),
     }
     return contents

--- a/lua/lspsaga/lspkind.lua
+++ b/lua/lspsaga/lspkind.lua
@@ -57,7 +57,7 @@ local function init_kind()
   for k, v in pairs(ui.kind) do
     local index = find_index_by_type(k)
     if not index then
-      vim.notify('[lspsaga.nvim] not found kind in default')
+      vim.notify('[lspsaga.nvim] could not find kind in default')
       return
     end
     if type(v) == 'table' then

--- a/lua/lspsaga/outline.lua
+++ b/lua/lspsaga/outline.lua
@@ -552,7 +552,7 @@ function ot:outline(no_close)
     return
   end
   if self.pending_request then
-    vim.notify('[lspsaga.nvim] there already have a request for outline please wait')
+    vim.notify('[lspsaga.nvim] there is already a request for outline please wait')
     return
   end
 


### PR DESCRIPTION
I went through and just fixed any grammatical errors I noticed. This includes things like, "Sorry does not any Definition Found" in the attached screenshot. (Love your work by the way!)


![Screenshot_2023-02-05-05-23-13_1920x1080](https://user-images.githubusercontent.com/47364240/216822716-33f703ac-c627-40b8-9bab-648ab95d4409.png)
