### PR TITLE
fix: error when showing diagnostic if lsp signs are disabled

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -57,7 +57,7 @@ function diag:code_action_cb()
   end
 
   local fix_title = diag_conf.custom_fix
-    or self.theme.left .. ui.code_action .. 'Fix ' .. self.theme.right
+      or self.theme.left .. ui.code_action .. 'Fix ' .. self.theme.right
 
   local contents = {
     '',
@@ -407,11 +407,10 @@ function diag:render_diagnostic_window(entry, option)
     callback = function()
       vim.defer_fn(function()
         local cur = api.nvim_get_current_buf()
-        if
-          cur ~= current_buffer
-          and cur ~= self.bufnr
-          and self.bufnr
-          and api.nvim_buf_is_loaded(self.bufnr)
+        if cur ~= current_buffer
+            and cur ~= self.bufnr
+            and self.bufnr
+            and api.nvim_buf_is_loaded(self.bufnr)
         then
           api.nvim_win_close(self.winid, true)
           if self.virt_winid and api.nvim_win_is_valid(self.virt_winid) then
@@ -489,23 +488,23 @@ function diag:show(entrys, arg, type)
   for _, entry in pairs(entrys) do
     local start_col = entry.end_col > entry.col and entry.col or entry.end_col
     local end_col = entry.end_col > entry.col and entry.end_col or entry.col
-    local code_source =
-      api.nvim_buf_get_text(entry.bufnr, entry.lnum, start_col, entry.lnum, end_col, {})
+    local code_source = api.nvim_buf_get_text(
+      entry.bufnr, entry.lnum, start_col, entry.lnum, end_col, {})
     insert(len, #code_source[1])
-    local sign = get_diagnostic_sign(get_diag_type(entry.severity))[1]
+    local sign = get_diagnostic_sign(get_diag_type(entry.severity))[1] or {}
     if not sign.text then
       sign.text = ui.diagnostic
     end
     local line = sign.text
-      .. ' '
-      .. code_source[1]
-      .. '  '
-      .. entry.lnum + 1
-      .. ':'
-      .. entry.col
-      .. '\n'
-      .. '  '
-      .. entry.message
+        .. ' '
+        .. code_source[1]
+        .. '  '
+        .. entry.lnum + 1
+        .. ':'
+        .. entry.col
+        .. '\n'
+        .. '  '
+        .. entry.message
     if entry.source then
       line = line .. '(' .. entry.source .. ')'
     end
@@ -555,7 +554,7 @@ function diag:show(entrys, arg, type)
     end
     local diag_type = get_diag_type(entrys[k].severity)
     local hi = 'Diagnostic' .. diag_type
-    local sign = get_diagnostic_sign(diag_type)[1]
+    local sign = get_diagnostic_sign(diag_type)[1] or {}
     local col_end = sign.text and #sign.text + 1 or 1
     api.nvim_buf_add_highlight(self.lnum_bufnr, 0, hi, index, 0, col_end)
     api.nvim_buf_add_highlight(

--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -57,7 +57,7 @@ function diag:code_action_cb()
   end
 
   local fix_title = diag_conf.custom_fix
-      or self.theme.left .. ui.code_action .. 'Fix ' .. self.theme.right
+    or self.theme.left .. ui.code_action .. 'Fix ' .. self.theme.right
 
   local contents = {
     '',
@@ -407,10 +407,11 @@ function diag:render_diagnostic_window(entry, option)
     callback = function()
       vim.defer_fn(function()
         local cur = api.nvim_get_current_buf()
-        if cur ~= current_buffer
-            and cur ~= self.bufnr
-            and self.bufnr
-            and api.nvim_buf_is_loaded(self.bufnr)
+        if
+          cur ~= current_buffer
+          and cur ~= self.bufnr
+          and self.bufnr
+          and api.nvim_buf_is_loaded(self.bufnr)
         then
           api.nvim_win_close(self.winid, true)
           if self.virt_winid and api.nvim_win_is_valid(self.virt_winid) then
@@ -488,23 +489,23 @@ function diag:show(entrys, arg, type)
   for _, entry in pairs(entrys) do
     local start_col = entry.end_col > entry.col and entry.col or entry.end_col
     local end_col = entry.end_col > entry.col and entry.end_col or entry.col
-    local code_source = api.nvim_buf_get_text(
-      entry.bufnr, entry.lnum, start_col, entry.lnum, end_col, {})
+    local code_source =
+      api.nvim_buf_get_text(entry.bufnr, entry.lnum, start_col, entry.lnum, end_col, {})
     insert(len, #code_source[1])
     local sign = get_diagnostic_sign(get_diag_type(entry.severity))[1] or {}
     if not sign.text then
       sign.text = ui.diagnostic
     end
     local line = sign.text
-        .. ' '
-        .. code_source[1]
-        .. '  '
-        .. entry.lnum + 1
-        .. ':'
-        .. entry.col
-        .. '\n'
-        .. '  '
-        .. entry.message
+      .. ' '
+      .. code_source[1]
+      .. '  '
+      .. entry.lnum + 1
+      .. ':'
+      .. entry.col
+      .. '\n'
+      .. '  '
+      .. entry.message
     if entry.source then
       line = line .. '(' .. entry.source .. ')'
     end


### PR DESCRIPTION
When LSP signs are disabled `vim.diagnostic.config({ signs = false })`, calling `:Lspasaga show_cursor_diagnostics` produces the following error
```
Error executing Lua callback: ...ack/packer/start/lspsaga.nvim/lua/lspsaga/diagnostic.lua:496: attempt to index local 'sign' (a nil value)
```
When checking the source I noticed that when signs are disabled calling `vim.fn.sign_getdefined` returns an empty list.

Note: formatting was applied by my LSP suneko Lua server