### PR TITLE
Adding go to type definition functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ keymap("n", "gd", "<cmd>Lspsaga peek_definition<CR>")
 -- Go to definition
 keymap("n","gd", "<cmd>Lspsaga goto_definition<CR>")
 
+-- Peek type definition
+-- You can edit the file containing the type definition in the floating window
+-- It also supports open/vsplit/etc operations, do refer to "definition_action_keys"
+-- It also supports tagstack
+-- Use <C-t> to jump back
+keymap("n", "gt", "<cmd>Lspsaga peek_type_definition<CR>")
+
+-- Go to type definition
+keymap("n","gt", "<cmd>Lspsaga goto_type_definition<CR>")
+
+
 -- Show line diagnostics
 -- You can pass argument ++unfocus to
 -- unfocus the show_line_diagnostics floating window
@@ -330,8 +341,8 @@ Default options:
 
 - Using `go_action`, you can quickly jump to line where actions need to be taken in the diagnostics floating window.
 - `jump_num_shortcut` - The default is `true`. After jumping, Lspasga will automatically bind code actions to a number. Afterwards, you can press the number to execute the code action. After the floating window is closed, these numbers will no longer be tied to the same code actions.
-- `custom_msg` string  used to  custom the diagnostic jump `Msg` section titile 
-- `custom_fix` string  used to  custom the diagnostic jump `Fix` section titile 
+- `custom_msg` string used to custom the diagnostic jump `Msg` section titile
+- `custom_fix` string used to custom the diagnostic jump `Fix` section titile
 - `max_width` is the max width for diagnostic jump window. percentage
 - `text_hl_follow` is false default true that you can define `DiagnostcText` to custom the diagnotic
   text color
@@ -487,7 +498,7 @@ Default options:
 - `hide_keyword` - The default value is `true`. Lspsaga will hide some keywords and temporary variables to make the symbols look cleaner.
 - `folder_level` only works when `show_file` is `true`.
 - `respect_root` will respect the LSP's root. If this is `true`, Lspsaga will ignore the `folder_level` option. If no LSP client is being used, Lspsaga will fall back to using folder level.
-- `color_mode` - The default value is `true`. When it is set  to `false`, only icons will have color.
+- `color_mode` - The default value is `true`. When it is set to `false`, only icons will have color.
 
 <details>
 <summary>Symbols in winbar</summary>

--- a/doc/lspsaga.nvim.txt
+++ b/doc/lspsaga.nvim.txt
@@ -12,8 +12,6 @@ Table of Contents                             *lspsaga.nvim-table-of-contents*
   - :Lspsaga lsp_finder                     |lspsaga.nvim-:lspsaga-lsp_finder|
   - :Lspsaga peek_definition           |lspsaga.nvim-:lspsaga-peek_definition|
   - :Lspsaga goto_definition           |lspsaga.nvim-:lspsaga-goto_definition|
-  - :Lspsaga peek_type_definition |lspsaga.nvim-:lspsaga-peek_type_definition|
-  - :Lspsaga goto_type_definition |lspsaga.nvim-:lspsaga-goto_type_definition|
   - :Lspsaga code_action                   |lspsaga.nvim-:lspsaga-code_action|
   - :Lspsaga Lightbulb                       |lspsaga.nvim-:lspsaga-lightbulb|
   - :Lspasga hover_doc                       |lspsaga.nvim-:lspasga-hover_doc|
@@ -153,7 +151,7 @@ PACKER <HTTPS://GITHUB.COM/WBTHOMASON/PACKER.NVIM>*lspsaga.nvim-packer-<https://
     -- Use <C-t> to jump back
     keymap("n", "gt", "<cmd>Lspsaga peek_type_definition<CR>")
     
-    -- Go to definition
+    -- Go to type definition
     keymap("n","gt", "<cmd>Lspsaga goto_type_definition<CR>")
     
     
@@ -306,32 +304,6 @@ src="https://user-images.githubusercontent.com/41671631/215719806-0dea0248-4a2c-
 :LSPSAGA GOTO_DEFINITION               *lspsaga.nvim-:lspsaga-goto_definition*
 
 Jumps to the definition of the hovered word and shows a beacon highlight.
-
-:LSPSAGA PEEK_TYPE_DEFINITION     *lspsaga.nvim-:lspsaga-peek_type_definition*
-
-There are two commands, `:Lspsaga peek_type_definition` and `:Lspsaga
-goto_type_definition`. The `peek_type_definition` command works by identifying
-the type of the hovered word and showing the file where the type is defined in
-an editable floating window.
-
-Default options:
-
->
-      type_definition = {
-        edit = "<C-c>o",
-        vsplit = "<C-c>v",
-        split = "<C-c>i",
-        tabe = "<C-c>t",
-        quit = "q",
-        close = "<Esc>",
-      }
-<
-
-
-:LSPSAGA GOTO_TYPE_DEFINITION     *lspsaga.nvim-:lspsaga-goto_type_definition*
-
-Jumps to the definition of the type of the hovered word and shows a beacon
-highlight.
 
 :LSPSAGA CODE_ACTION                       *lspsaga.nvim-:lspsaga-code_action*
 

--- a/doc/lspsaga.nvim.txt
+++ b/doc/lspsaga.nvim.txt
@@ -12,6 +12,8 @@ Table of Contents                             *lspsaga.nvim-table-of-contents*
   - :Lspsaga lsp_finder                     |lspsaga.nvim-:lspsaga-lsp_finder|
   - :Lspsaga peek_definition           |lspsaga.nvim-:lspsaga-peek_definition|
   - :Lspsaga goto_definition           |lspsaga.nvim-:lspsaga-goto_definition|
+  - :Lspsaga peek_type_definition |lspsaga.nvim-:lspsaga-peek_type_definition|
+  - :Lspsaga goto_type_definition |lspsaga.nvim-:lspsaga-goto_type_definition|
   - :Lspsaga code_action                   |lspsaga.nvim-:lspsaga-code_action|
   - :Lspsaga Lightbulb                       |lspsaga.nvim-:lspsaga-lightbulb|
   - :Lspasga hover_doc                       |lspsaga.nvim-:lspasga-hover_doc|
@@ -143,6 +145,17 @@ PACKER <HTTPS://GITHUB.COM/WBTHOMASON/PACKER.NVIM>*lspsaga.nvim-packer-<https://
     
     -- Go to definition
     keymap("n","gd", "<cmd>Lspsaga goto_definition<CR>")
+    
+    -- Peek type definition
+    -- You can edit the file containing the type definition in the floating window
+    -- It also supports open/vsplit/etc operations, do refer to "definition_action_keys"
+    -- It also supports tagstack
+    -- Use <C-t> to jump back
+    keymap("n", "gt", "<cmd>Lspsaga peek_type_definition<CR>")
+    
+    -- Go to definition
+    keymap("n","gt", "<cmd>Lspsaga goto_type_definition<CR>")
+    
     
     -- Show line diagnostics
     -- You can pass argument ++unfocus to
@@ -293,6 +306,32 @@ src="https://user-images.githubusercontent.com/41671631/215719806-0dea0248-4a2c-
 :LSPSAGA GOTO_DEFINITION               *lspsaga.nvim-:lspsaga-goto_definition*
 
 Jumps to the definition of the hovered word and shows a beacon highlight.
+
+:LSPSAGA PEEK_TYPE_DEFINITION     *lspsaga.nvim-:lspsaga-peek_type_definition*
+
+There are two commands, `:Lspsaga peek_type_definition` and `:Lspsaga
+goto_type_definition`. The `peek_type_definition` command works by identifying
+the type of the hovered word and showing the file where the type is defined in
+an editable floating window.
+
+Default options:
+
+>
+      type_definition = {
+        edit = "<C-c>o",
+        vsplit = "<C-c>v",
+        split = "<C-c>i",
+        tabe = "<C-c>t",
+        quit = "q",
+        close = "<Esc>",
+      }
+<
+
+
+:LSPSAGA GOTO_TYPE_DEFINITION     *lspsaga.nvim-:lspsaga-goto_type_definition*
+
+Jumps to the definition of the type of the hovered word and shows a beacon
+highlight.
 
 :LSPSAGA CODE_ACTION                       *lspsaga.nvim-:lspsaga-code_action*
 

--- a/lua/lspsaga/command.lua
+++ b/lua/lspsaga/command.lua
@@ -5,10 +5,16 @@ local subcommands = {
     require('lspsaga.finder'):lsp_finder()
   end,
   peek_definition = function()
-    require('lspsaga.definition'):peek_definition()
+    require('lspsaga.definition'):peek_definition(1)
   end,
   goto_definition = function()
-    require('lspsaga.definition'):goto_definition()
+    require('lspsaga.definition'):goto_definition(1)
+  end,
+  peek_type_definition = function()
+    require('lspsaga.definition'):peek_definition(2)
+  end,
+  goto_type_definition = function()
+    require('lspsaga.definition'):goto_definition(2)
   end,
   rename = function(arg)
     require('lspsaga.rename'):lsp_rename(arg)


### PR DESCRIPTION
Cf issue #850 

* Adding go to type definition functionality mimicking the go to definition implementation.
* Updating the docs with the relevant information to inform on the feature.

Happy to make any changes in the docs or code, I wasn't able to reproduce the same theme as the other showcase so decided against adding an image for the sake of uniformity of style in the docs.