### PR TITLE
fix: error when calling hover if no information available

### DIFF
--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -38,6 +38,10 @@ function hover:open_floating_preview(res, option_fn)
   self.preview_bufnr = api.nvim_create_buf(false, true)
 
   local content = vim.split(res.value, '\n', { trimempty = true })
+  if #content == 0 then
+    vim.notify('No information available')
+    return
+  end
 
   local new = {}
   for _, line in pairs(content) do


### PR DESCRIPTION
I got error if no information is available on hover.

```
Error executing vim.schedule lua callback: ...s/github.com/glepnir/lspsaga.nvim/lua/lspsaga/window.lua:339: attempt to compa
re number with nil
stack traceback:
        ...s/github.com/glepnir/lspsaga.nvim/lua/lspsaga/window.lua:339: in function 'win_height_increase'
        ...os/github.com/glepnir/lspsaga.nvim/lua/lspsaga/hover.lua:73: in function 'open_floating_preview'
        ...os/github.com/glepnir/lspsaga.nvim/lua/lspsaga/hover.lua:213: in function 'handler'
        ...r/neovim/HEAD-42d5142/share/nvim/runtime/lua/vim/lsp.lua:1391: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```