### PR TITLE
Add caveat around highlight groups in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,9 +519,14 @@ Default options:
 ## :Lspsaga symbols in a custom winbar/statusline
 
 Lspsaga provides an API that you can use in your custom winbar or statusline.
+When using this method, you may also have to append `'%#EndOfBuffer#'` or
+another highlight group to fix the highliting.
 
 ```lua
 vim.wo.winbar / vim.wo.stl = require('lspsaga.symbolwinbar'):get_winbar()
+
+-- To fix highlighting, try something like this
+vim.wo.winbar / vim.wo.stl = require('lspsaga.symbolwinbar'):get_winbar() .. '%#EndOfBuffer#'
 ```
 
 ## :Lspsaga term_toggle


### PR DESCRIPTION
Closes #879

Feel free to disregard this and close this PR if you don't think it's necessary, but it was relatively difficult to debug why this was rendering strangely. More screenshots and explanation of the bug this fixes in #879 