### PR TITLE
Provider the `clean_ctx` public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ The steps demonstrated in this showcase are:
 - Pressing `<C-c>o` to jump to the file in the floating window
 - Lspsaga shows a beacon highlight after jumping to the file
 
+When you find that the definition window can't be closed by `q`, maybe you used `ctrl-o` or some wincmd to break the stack, you need to clear the ctx manually, you can use `lua require('lspsaga.definition').clean_ctx()` to do that.
+
 <img src="https://user-images.githubusercontent.com/41671631/215719806-0dea0248-4a2c-45df-a258-43a4ba207a43.gif" height=80% width=80%/>
 </details>
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ The steps demonstrated in this showcase are:
 - Pressing `<C-c>o` to jump to the file in the floating window
 - Lspsaga shows a beacon highlight after jumping to the file
 
-When you find that the definition window can't be closed by `q`, maybe you used `ctrl-o` or some wincmd to break the stack, you need to clear the ctx manually, you can use `lua require('lspsaga.definition').clean_ctx()` to do that.
+When you find that the definition window can't be closed by `q`, maybe you broke the stack with `ctrl-o` or some wincmd, you need to clear the ctx manually, you can use `lua require('lspsaga.definition').clean_ctx()` to do that.
 
 <img src="https://user-images.githubusercontent.com/41671631/215719806-0dea0248-4a2c-45df-a258-43a4ba207a43.gif" height=80% width=80%/>
 </details>

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -368,6 +368,10 @@ function def:goto_definition(method)
   end
 end
 
+function def:clean_ctx()
+  clean_ctx()
+end
+
 def = setmetatable(def, {
   __newindex = function(_, k, v)
     ctx[k] = v


### PR DESCRIPTION
I think  this is a simpler solusion to fix #888 , because having this public API, when I find I can't close the window by `q`, I know I need to clean the ctx, that is much better than restarting the nvim.
