### PR TITLE
definition: fix typo

### DIFF
--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -96,7 +96,7 @@ function def:apply_aciton_keys(buf)
 
         local node = ctx[index]
         api.nvim_win_close(self.winid, true)
-        vim.cmd(action .. ' ' .. vim.urit_to_fname(node.uri))
+        vim.cmd(action .. ' ' .. vim.uri_to_fname(node.uri))
         api.nvim_win_set_cursor(0, { node.pos[1] + 1, node.pos[2] })
         local width = #api.nvim_get_current_line()
         libs.jump_beacon({ node.pos[1], node.pos[2] }, width)


### PR DESCRIPTION
The current state of lspsaga doesn't work with nightly neovim version, this change should fix that