### PR TITLE
Check if any servers support code actions in diagnostics

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -169,7 +169,10 @@ function diag:render_diagnostic_window(entry, option)
   vim.list_extend(content, convert)
   content[#content] = content[#content] .. source
 
-  if diag_conf.show_code_action then
+  if
+    diag_conf.show_code_action
+    and libs.get_client_by_cap({ 'codeActionProvider', 'resolveProvider' })
+  then
     act:send_code_action_request(self.main_buf, {
       range = {
         start = { entry.lnum + 1, entry.col },

--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -242,8 +242,7 @@ function libs.get_client_by_cap(caps)
     ['table'] = function(instance)
       libs.add_client_filetypes(instance, { vim.bo.filetype })
       if
-        instance.server_capabilities[caps[1]]
-        and instance.server_capabilities[caps[2]]
+        vim.tbl_get(instance.server_capabilities, unpack(caps))
         and libs.has_value(instance.config.filetypes, vim.bo.filetype)
       then
         return instance


### PR DESCRIPTION
Love the new release!

I stumbled upon the following error jumping to a diagnostic (`:Lspsaga diagnostic_jump_prev`) when none of the LSPs support code actions:

```
method textDocument/codeAction is not supported by any of the servers registered for the current buffer
```

I tracked it to this line:
https://github.com/glepnir/lspsaga.nvim/blob/688a3d835a4533ebd2c1ebb7e7c22d53385975d5/lua/lspsaga/codeaction.lua#L163

Looking at other parts of your code, it looks like it's fallible and you had a check for it. For example, `send_request()` has a similar call:
https://github.com/glepnir/lspsaga.nvim/blob/688a3d835a4533ebd2c1ebb7e7c22d53385975d5/lua/lspsaga/lightbulb.lua#L112

And it has the following check before it gets called:
https://github.com/glepnir/lspsaga.nvim/blob/688a3d835a4533ebd2c1ebb7e7c22d53385975d5/lua/lspsaga/lightbulb.lua#L136-L142

So I extracted `check_server_support_codeaction(bufnr)` to `libs` and added it as a check before asking for the possible code actions