### PR TITLE
diagnostic: Take amount of num_shortcuts to delete from same list as they were created with

### DIFF
--- a/lua/lspsaga/diagnostic.lua
+++ b/lua/lspsaga/diagnostic.lua
@@ -98,8 +98,8 @@ function diag:code_action_cb()
 
   if diag_conf.jump_num_shortcut then
     self.remove_num_map = function()
-      for i = 3, #contents do
-        pcall(vim.keymap.del, 'n', tostring(i - 2), { buffer = self.main_buf })
+      for i = 1, #(act.action_tuples or {}) do
+        pcall(vim.keymap.del, 'n', tostring(i), { buffer = self.main_buf })
       end
     end
 


### PR DESCRIPTION
I experienced the same error/a similar error as mentioned in #754.
I noticed that it only happened on certain numbers (specifically the number of the last code action as it turned out).

I tracked it down to the deletion loop.
I think the problem was that at the time the loop was introduced (a1188f2) there was more text added to `contents`.

But if I am not mistaken the proposed implementation will delete exactly as many mappings as there were created because it takes the length from the same list.


---

And a huge thank you for the great plugin glepnir!!