### PR TITLE
fix small finder windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Default options:
   finder = {
     --percentage
     max_height = 0.5,
+    force_max_height = false
     keys = {
       jump_to = 'p',
       edit = { 'o', '<CR>' },
@@ -214,6 +215,7 @@ Default options:
 ```
 
 - `max_height` of the finder window.
+- `force_max_height` force window height to max_height
 - `keys.jump_to` finder peek window.
 - `close_in_preview` will close all finder window in when you in preview window.
 

--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -353,7 +353,7 @@ function finder:render_finder_result()
 
   local max_height = math.floor(vim.o.lines * config.finder.max_height)
   opt.height = #self.contents > max_height and max_height or #self.contents
-  if opt.height <= 0 or not opt.height then
+  if opt.height <= 0 or not opt.height or config.finder.force_max_height then
     opt.height = max_height
   end
 

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -63,6 +63,7 @@ local default_config = {
   finder = {
     --percentage
     max_height = 0.5,
+    force_max_height = false,
     keys = {
       jump_to = 'p',
       edit = { 'o', '<CR>' },


### PR DESCRIPTION
# Issue
The finder window in `lspsaga.nvim` is often too small to display its content, because its size is calculated as the minimum of the content size (proportional to a number of references) and the maximum size from the configuration. This can be a problem when the number of references is too small because it leads to a small preview window.

# Solution
I've added a new configuration option, `finder.force_max_height`, that allows the user to force the window to the maximum size, even if the content is smaller. This can be useful when the content is smaller than the maximum size, but the user still wants to maximize the window to make it easier to read.

# Usage
The `finder.force_max_height option` is a boolean value that defaults to false. When set to true, it will force the finder window to the maximum size specified in the configuration, even if the content is smaller.

Here's an example configuration that uses force_max_height:

```lua
require('lspsaga').setup({
  finder = {
    max_height = 0.8,
    force_max_height = true, -- new option to force maximum height
  },
  -- other configuration options...
}
```
# Implementation
I implemented the `finder.force_max_height` option by modifying the calculation of the window height in the `finder:render_finder_result()` function. When `finder.force_max_height` is set to true, the window height is always set to the maximum size specified in the configuration. When `finder.force_max_height` is false, the window height is calculated as before.