### PR TITLE
hover: change fallback browser to xdg-open

### DIFF
--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -21,7 +21,7 @@ local default_config = {
   hover = {
     max_width = 0.6,
     open_link = 'gx',
-    open_browser = '!chrome',
+    open_browser = '!xdg-open',
   },
   diagnostic = {
     on_insert = true,


### PR DESCRIPTION
https://github.com/glepnir/lspsaga.nvim/blob/d47c2dbfa16b95563233bf23703e9f8b04b7a969/lua/lspsaga/hover.lua#L36-L42

A better fallback URI opener is `xdg-open`, it is the most widespread [resource opener](https://wiki.archlinux.org/title/default_applications#Resource_openers). It also works on [BSD](https://man.freebsd.org/cgi/man.cgi?query=xdg-open&sektion=1&manpath=freebsd-release-ports). Other users will have to change the configuration option to suit their needs.

By the way, note that most Linux distributions don't use `chrome`, but `google-chrome`, or `google-chrome-stable`. A lot of Linux users use `chromium-browser` as it's non-proprietary. Not to mention users of other internet browsers.