### PR TITLE
fix ++unfocus arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,6 @@ keymap("n","gt", "<cmd>Lspsaga goto_type_definition<CR>")
 -- unfocus the show_line_diagnostics floating window
 keymap("n", "<leader>sl", "<cmd>Lspsaga show_line_diagnostics<CR>")
 
--- Show cursor diagnostics
--- Like show_line_diagnostics, it supports passing the ++unfocus argument
-keymap("n", "<leader>sc", "<cmd>Lspsaga show_cursor_diagnostics<CR>")
-
 -- Show buffer diagnostics
 keymap("n", "<leader>sb", "<cmd>Lspsaga show_buf_diagnostics<CR>")
 

--- a/lua/lspsaga/showdiag.lua
+++ b/lua/lspsaga/showdiag.lua
@@ -96,7 +96,7 @@ function sd:create_win(opt, content)
 
   local close_autocmds =
     { 'CursorMoved', 'CursorMovedI', 'InsertEnter', 'BufDelete', 'WinScrolled' }
-  if arg and arg == '++unfocus' then
+  if opt.arg and opt.arg == '++unfocus' then
     opt.focusable = false
     close_autocmds[#close_autocmds] = 'BufLeave'
     content_opt.enter = false


### PR DESCRIPTION
Hey, it looks like ++unfocus flag is not respected right now.  I've a one minor question out of topic. Will you add `Lspsaga show_cursor_dignostics` back. I was using it a lot and my workflow has broken after the last update here is the my work around for now.

```
lua require('lspsaga.showdiag'):show_diagnostics({ cursor = true, arg = '++unfocus' })
```