### PR TITLE
fix: `scroll_preview` maps not deleted after docs window closed

### DIFF
--- a/lua/lspsaga/libs.lua
+++ b/lua/lspsaga/libs.lua
@@ -153,6 +153,7 @@ function libs.close_preview_autocmd(bufnr, winids, events, cb)
       window.nvim_close_valid_window(winids)
       if cb then
         cb(opt.event)
+        libs.delete_scroll_map(bufnr)
       end
     end,
   })
@@ -275,8 +276,8 @@ end
 
 function libs.delete_scroll_map(bufnr)
   local config = require('lspsaga').config
-  vim.keymap.del('n', config.scroll_preview.scroll_down, { buffer = bufnr })
-  vim.keymap.del('n', config.scroll_preview.scroll_up, { buffer = bufnr })
+  pcall(vim.keymap.del, 'n', config.scroll_preview.scroll_down, { buffer = bufnr })
+  pcall(vim.keymap.del, 'n', config.scroll_preview.scroll_up, { buffer = bufnr })
 end
 
 function libs.jump_beacon(bufpos, width)


### PR DESCRIPTION
Hi there, i was getting this weird error from scroll preview window when trying to use the <C-d> in buffer because these up and down keys were not getting deleted after the preview window was closed.

I am new programmer so lurking around in a big code base is not my greatest power so what i had in my knowledge tried to use and came up with this messy solution which isn't great but you can fix it.

```
   E5108: Error executing lua: .../share/nvim/lazy/lspsaga.nvim/lua/lspsaga/diagnostic.lua:125: Invalid window id: 1061
stack traceback:
	[C]: in function 'nvim_win_call'
	.../share/nvim/lazy/lspsaga.nvim/lua/lspsaga/diagnostic.lua:125: in function 'scroll_with_preview'
	.../share/nvim/lazy/lspsaga.nvim/lua/lspsaga/diagnostic.lua:147: in function <.../share/nvim/lazy/lspsaga.nvim/lua/lspsaga/diagnostic.lua:146>
```