### PR TITLE
fix treesitter highlight for unloaded buffer

### DIFF
--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -839,10 +839,10 @@ function finder:open_preview(node)
     end, 5)
     node.loaded = true
   elseif fn.has('nvim-0.8') == 1 and node.wipe then
-    api.nvim_buf_call(node.bufnr, function()
-      vim.defer_fn(function()
+    vim.schedule(function ()
+      api.nvim_buf_call(node.bufnr, function()
         vim.cmd('TSBufEnable highlight')
-      end, 5)
+      end)
     end)
   end
 end


### PR DESCRIPTION
Treesitter highlight is not working for unloaded buffers.
<img width="649" alt="Screen Shot 2023-03-28 at 20 26 05" src="https://user-images.githubusercontent.com/22982681/228236080-bc755a19-4499-4b49-bfcd-e769debd1244.png">
fixed by this commit:
<img width="858" alt="Screen Shot 2023-03-28 at 20 26 52" src="https://user-images.githubusercontent.com/22982681/228236185-5f8659ba-2f06-4069-bbf4-63064358fd69.png">
