### PR TITLE
Only change highlights locally in showdiag

### DIFF
--- a/lua/lspsaga/showdiag.lua
+++ b/lua/lspsaga/showdiag.lua
@@ -261,7 +261,7 @@ function sd:show(opt)
   vim.bo[self.bufnr].modifiable = false
 
   local nontext = api.nvim_get_hl_by_name('NonText', true)
-  api.nvim_set_hl(0, 'NonText', {
+  api.nvim_set_hl(ns, 'NonText', {
     link = 'FinderLines',
   })
 


### PR DESCRIPTION
My reason for this change: opening lspsaga's diagnostics changed the color of listchars (that can show for example spaces) from gray to white.