### PR TITLE
fix: make showdiag respect config.ui.title

### DIFF
--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -510,7 +510,7 @@ function ch:preview()
   end
 
   api.nvim_win_set_buf(self.preview_winid, data.bufnr)
-  if config.ui.title and fn.has('nvim-0.9') == 1 then
+  if fn.has('nvim-0.9') == 1 and config.ui.title then
     local path = vim.split(api.nvim_buf_get_name(data.bufnr), libs.path_sep, { trimempty = true })
     local icon = libs.icon_from_devicon(vim.bo[self.main_buf].filetype)
     api.nvim_win_set_config(self.preview_winid, {

--- a/lua/lspsaga/showdiag.lua
+++ b/lua/lspsaga/showdiag.lua
@@ -71,7 +71,7 @@ function sd:create_win(opt, content)
     no_size_override = true,
   }
 
-  if fn.has('nvim-0.9') == 1 then
+  if fn.has('nvim-0.9') == 1 and config.ui.title then
     if opt.buffer then
       float_opt.title = 'Buffer'
     elseif opt.line then


### PR DESCRIPTION
Currently, `config.ui.title` is not respected for diagnostics.

For example, `Lspsaga show_line_diagnostics` shows a `Line` title.

This PR fixes that, as well as makes the version/config.ui.title check ordering consistent in `callhierarchy.lua` where it was reversed.