### PR TITLE
fix: any hover client succeeding suppresses 'No information available'

### DIFF
--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -184,7 +184,10 @@ local in_process = 0
 function def:peek_definition(method)
   local cur_winid = api.nvim_get_current_win()
   if in_process == cur_winid then
-    vim.notify('[Lspsaga] There is already a peek_definition request, please wait for the response.', vim.log.levels.WARN)
+    vim.notify(
+      '[Lspsaga] There is already a peek_definition request, please wait for the response.',
+      vim.log.levels.WARN
+    )
     return
   end
 

--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -211,14 +211,38 @@ end
 
 function hover:do_request(args)
   local params = util.make_position_params()
+
+  local expected_result_count = 0
+  lsp.for_each_buffer_client(0, function(client)
+    if client.supports_method('textDocument/hover') then
+      expected_result_count = expected_result_count + 1
+    end
+  end)
+
+  local result_count = 0
+  local has_succeeded = false
+
+  local should_error = function()
+    -- Never error if we have ++quiet
+    if args and has_arg(args, '++quiet') then
+      return false
+    end
+
+    -- Only error if all of the possible responding servers did not succeed
+    return result_count == expected_result_count and not has_succeeded
+  end
+
   lsp.buf_request(0, 'textDocument/hover', params, function(_, result, ctx)
     self.pending_request = false
+
+    result_count = result_count + 1
+
     if api.nvim_get_current_buf() ~= ctx.bufnr then
       return
     end
 
     if not result or not result.contents then
-      if not args or not has_arg(args, '++quiet') then
+      if should_error() then
         vim.notify('No information available')
       end
       return
@@ -233,7 +257,7 @@ function hover:do_request(args)
     elseif result.contents.language then -- MarkedString
       value = result.contents.value
     elseif vim.tbl_islist(result.contents) then -- MarkedString[]
-      if vim.tbl_isempty(result.contents) then
+      if vim.tbl_isempty(result.contents) and should_error() then
         vim.notify('No information available')
         return
       end
@@ -263,6 +287,7 @@ function hover:do_request(args)
       end
     end
 
+    has_succeeded = true
     self:open_floating_preview(result.contents, option_fn)
   end)
 end

--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -219,6 +219,11 @@ function hover:do_request(args)
     end
   end)
 
+  if expected_result_count == 0 then
+    vim.notify('No information available')
+    return
+  end
+
   local result_count = 0
   local has_succeeded = false
 


### PR DESCRIPTION
Currently, if there are two lsp clients that may report supporting `textDocument/hover`, and one of them "fails" the hover while the other succeeds, a hover will popup **and** "No information available" will be notified.

This PR makes it so that "No information available" is only notified if all the possible clients have have also failed.

(Note: I didn't use `lsp.buf_request_all` because that doesn't pass the `ctx` object to the callback, which is currently used)

Example:
![image](https://user-images.githubusercontent.com/20625636/229673136-26a4976f-0198-41e7-a0dc-33fcd76d6a1b.png)

The two servers that are being activated are `tsserver` and `tailwindcss`. Tailwindcss will only hover in cases where you're hovering over a tailwindcss class, so it makes sense that it returning `nil` for the response.

This PR doesn't address that two clients returning non-null values may overlap/have a race condition - I'm not sure what the expected behavior should be in that situation